### PR TITLE
Add standalone grammar and YAML parsing updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,23 @@ data, deftly!
 
 ## Usage
 
-**TODO**
+To parse a YAML mapping of output columns to operations, use `dftly.from_yaml`:
+
+```python
+from dftly import from_yaml
+
+text = """
+a: col1 + col2
+b: foo as int
+"""
+result = from_yaml(text, input_schema={"col1": "int", "col2": "int", "foo": "str"})
+```
+
+String expressions are parsed using a [Lark](https://github.com/lark-parser/lark) grammar
+defined in `src/dftly/grammar.lark`, making the
+implementation extensible beyond the simple examples shown above.
+
+The returned object contains instances of `dftly.Expression`, `dftly.Column`, and `dftly.Literal` representing the fully resolved operations.
 
 ## Design Documentation
 
@@ -90,7 +106,7 @@ objects, obeying one of the following simple templates:
 
 #### Literals
 
-Literals are simple string or typed literals (type determined via OmegaConf). They are expressed via a
+Literals are simple string or typed literals (type determined by the YAML parser). They are expressed via a
 one-element map with the key `literal` and the value being the literal value itself. For example:
 
 ```yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["omegaconf", "lark"]
+dependencies = ["PyYAML", "lark"]
 
 [tool.setuptools_scm]
 

--- a/src/dftly/__init__.py
+++ b/src/dftly/__init__.py
@@ -1,0 +1,13 @@
+"""dftly - DataFrame Transformation Language parser."""
+
+from .nodes import Column, Expression, Literal
+from .parser import Parser, from_yaml, parse
+
+__all__ = [
+    "Column",
+    "Expression",
+    "Literal",
+    "Parser",
+    "parse",
+    "from_yaml",
+]

--- a/src/dftly/grammar.lark
+++ b/src/dftly/grammar.lark
@@ -1,0 +1,19 @@
+%import common.CNAME -> NAME
+%import common.WS
+%ignore WS
+
+PLUS: "+"
+MINUS: "-"
+AS: /as/i
+IF: /if/i
+ELSE: /else/i
+
+start: expr
+expr: conditional
+conditional: additive IF additive ELSE conditional   -> ifexpr
+          | additive
+additive: cast_expr op*
+op: PLUS cast_expr     -> plus
+  | MINUS cast_expr    -> minus
+cast_expr: NAME AS NAME   -> cast
+         | NAME           -> name

--- a/src/dftly/nodes.py
+++ b/src/dftly/nodes.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
+
+@dataclass
+class Literal:
+    """A literal value."""
+
+    value: Any
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"literal": self.value}
+
+
+@dataclass
+class Column:
+    """Reference to a dataframe column."""
+
+    name: str
+    type: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {"name": self.name}
+        if self.type is not None:
+            data["type"] = self.type
+        return {"column": data}
+
+
+@dataclass
+class Expression:
+    """A parsed expression."""
+
+    type: str
+    arguments: Union[List[Any], Dict[str, Any]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"expression": {"type": self.type, "arguments": self.arguments}}

--- a/src/dftly/parser.py
+++ b/src/dftly/parser.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from importlib.resources import files
+
+from lark import Lark, Transformer
+
+from .nodes import Column, Expression, Literal
+
+
+class Parser:
+    """Parse simplified YAML-like structures into dftly nodes."""
+
+    def __init__(
+        self, input_schema: Optional[Mapping[str, Optional[str]]] = None
+    ) -> None:
+        self.input_schema = dict(input_schema or {})
+        grammar_text = files(__package__).joinpath("grammar.lark").read_text()
+        self._lark = Lark(grammar_text, parser="lalr")
+        self._transformer = DftlyTransformer(self)
+
+    def parse(self, data: Mapping[str, Any]) -> Dict[str, Any]:
+        if not isinstance(data, Mapping):
+            raise TypeError("top level data must be a mapping")
+        return {key: self._parse_value(value) for key, value in data.items()}
+
+    # ------------------------------------------------------------------
+    def _parse_value(self, value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return self._parse_mapping(value)
+        if isinstance(value, list):
+            # default behaviour: COALESCE
+            return Expression("COALESCE", [self._parse_value(v) for v in value])
+        if isinstance(value, (int, float, bool)):
+            return Literal(value)
+        if isinstance(value, str):
+            return self._parse_string(value)
+        raise TypeError(f"unsupported type: {type(value).__name__}")
+
+    # ------------------------------------------------------------------
+    def _parse_mapping(self, value: Mapping[str, Any]) -> Any:
+        if "literal" in value:
+            return Literal(value["literal"])
+        if "column" in value:
+            col_val = value["column"]
+            if isinstance(col_val, str):
+                return Column(col_val, self.input_schema.get(col_val))
+            if isinstance(col_val, Mapping):
+                name = col_val.get("name")
+                typ = col_val.get("type", self.input_schema.get(name))
+                return Column(name, typ)
+        if "expression" in value:
+            expr = value["expression"]
+            expr_type = expr.get("type")
+            args = expr.get("arguments", [])
+            parsed_args = self._parse_arguments(args)
+            return Expression(expr_type, parsed_args)
+        # dictionary short form for expressions
+        if len(value) == 1:
+            expr_type, args = next(iter(value.items()))
+            parsed_args = self._parse_arguments(args)
+            return Expression(expr_type.upper(), parsed_args)
+        raise ValueError("invalid mapping input")
+
+    # ------------------------------------------------------------------
+    def _parse_arguments(self, args: Any) -> Any:
+        if isinstance(args, Mapping):
+            return {k: self._parse_value(v) for k, v in args.items()}
+        if isinstance(args, list):
+            return [self._parse_value(a) for a in args]
+        return self._parse_value(args)
+
+    # ------------------------------------------------------------------
+
+    def _parse_string(self, value: str) -> Any:
+        try:
+            tree = self._lark.parse(value)
+            result = self._transformer.transform(tree)
+            return result
+        except Exception:
+            return self._as_node(value)
+
+    # ------------------------------------------------------------------
+    def _as_node(self, value: Any) -> Any:
+        if isinstance(value, (Expression, Column, Literal)):
+            return value
+        if isinstance(value, str):
+            if value in self.input_schema:
+                return Column(value, self.input_schema.get(value))
+            return Literal(value)
+        raise TypeError(f"cannot convert {type(value).__name__} to node")
+
+
+class DftlyTransformer(Transformer):
+    """Transform parsed tokens into dftly nodes."""
+
+    def __init__(self, parser: Parser) -> None:
+        super().__init__()
+        self.parser = parser
+
+    def NAME(self, token: Any) -> str:  # type: ignore[override]
+        return str(token)
+
+    def name(self, items: list[str]) -> str:  # type: ignore[override]
+        (val,) = items
+        return val
+
+    def expr(self, items: list[Any]) -> Any:  # type: ignore[override]
+        (item,) = items
+        return item
+
+    def conditional(self, items: list[Any]) -> Any:  # type: ignore[override]
+        (item,) = items
+        return item
+
+    def cast(self, items: list[Any]) -> Expression:  # type: ignore[override]
+        value = items[0]
+        out_type = items[-1]
+        return Expression(
+            "TYPE_CAST",
+            {
+                "input": self.parser._as_node(value),
+                "output_type": Literal(out_type),
+            },
+        )
+
+    def plus(self, items: list[Any]) -> Tuple[str, Any]:  # type: ignore[override]
+        _, val = items
+        return "+", val
+
+    def minus(self, items: list[Any]) -> Tuple[str, Any]:  # type: ignore[override]
+        _, val = items
+        return "-", val
+
+    def additive(self, items: list[Any]) -> Any:  # type: ignore[override]
+        base = self.parser._as_node(items[0])
+        if len(items) == 1:
+            return base
+        ops = items[1:]
+        symbols = [s for s, _ in ops]
+        operands = [self.parser._as_node(v) for _, v in ops]
+        if all(sym == "+" for sym in symbols):
+            return Expression("ADD", [base] + operands)
+        if all(sym == "-" for sym in symbols) and len(symbols) == 1:
+            return Expression("SUBTRACT", [base, operands[0]])
+        raise ValueError("invalid arithmetic expression")
+
+    def ifexpr(self, items: list[Any]) -> Expression:  # type: ignore[override]
+        then = items[0]
+        pred = items[2]
+        els = items[4]
+        return Expression(
+            "CONDITIONAL",
+            {
+                "if": self.parser._as_node(pred),
+                "then": self.parser._as_node(then),
+                "else": self.parser._as_node(els),
+            },
+        )
+
+    def start(self, items: list[Any]) -> Any:  # type: ignore[override]
+        (item,) = items
+        return item
+
+
+def parse(
+    data: Mapping[str, Any], input_schema: Optional[Mapping[str, Optional[str]]] = None
+) -> Dict[str, Any]:
+    """Parse simplified data into fully resolved form."""
+
+    parser = Parser(input_schema)
+    return parser.parse(data)
+
+
+def from_yaml(
+    yaml_text: str, input_schema: Optional[Mapping[str, Optional[str]]] = None
+) -> Dict[str, Any]:
+    """Parse from a YAML string."""
+
+    import yaml
+
+    data = yaml.safe_load(yaml_text) or {}
+    if not isinstance(data, Mapping):
+        raise TypeError("YAML input must produce a mapping")
+    return parse(data, input_schema)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,45 @@
+from dftly import from_yaml, Column, Expression, Literal
+
+
+def test_parse_addition():
+    text = "a: col1 + col2"
+    result = from_yaml(text, input_schema={"col1": "int", "col2": "int"})
+    expr = result["a"]
+    assert isinstance(expr, Expression)
+    assert expr.type == "ADD"
+    args = expr.arguments
+    assert isinstance(args, list)
+    assert isinstance(args[0], Column)
+    assert args[0].name == "col1"
+    assert isinstance(args[1], Column)
+    assert args[1].name == "col2"
+
+
+def test_parse_literal_string():
+    text = "a: hello"
+    result = from_yaml(text)
+    lit = result["a"]
+    assert isinstance(lit, Literal)
+    assert lit.value == "hello"
+
+
+def test_parse_subtract_and_cast_and_conditional():
+    text = """
+    a: col1 - col2
+    b: col3 as float
+    c: col1 if flag else col2
+    """
+    schema = {"col1": "int", "col2": "int", "col3": "str", "flag": "bool"}
+    result = from_yaml(text, input_schema=schema)
+
+    sub = result["a"]
+    assert isinstance(sub, Expression)
+    assert sub.type == "SUBTRACT"
+
+    cast = result["b"]
+    assert isinstance(cast, Expression)
+    assert cast.type == "TYPE_CAST"
+
+    cond = result["c"]
+    assert isinstance(cond, Expression)
+    assert cond.type == "CONDITIONAL"


### PR DESCRIPTION
## Summary
- move lark grammar into a standalone ``grammar.lark`` file
- replace OmegaConf YAML loading with ``yaml.safe_load``
- expose a standalone ``DftlyTransformer`` and update parser to load the grammar from file
- document grammar file path and YAML parsing behaviour
- update dependencies to use ``PyYAML``

## Testing
- `pre-commit run --files README.md pyproject.toml src/dftly/parser.py src/dftly/grammar.lark`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b69d63d4832c8b24210f9d78a15d