### PR TITLE
Add optional polars execution engine

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install packages
         run: |
-          pip install -e .[tests]
+          pip install -e .[tests,polars]
 
       #----------------------------------------------
       #              run test suite
@@ -34,14 +34,6 @@ jobs:
       - name: Run tests
         run: |
           pytest -v --doctest-modules --cov=src --junitxml=junit.xml -s --ignore=docs
-
-      - name: Install polars
-        run: |
-          pip install polars
-
-      - name: Run tests with polars
-        run: |
-          pytest -v --doctest-modules --cov=src -s --ignore=docs
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.0.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,14 @@ jobs:
         run: |
           pytest -v --doctest-modules --cov=src --junitxml=junit.xml -s --ignore=docs
 
+      - name: Install polars
+        run: |
+          pip install polars
+
+      - name: Run tests with polars
+        run: |
+          pytest -v --doctest-modules --cov=src -s --ignore=docs
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ data, deftly!
 
 `pip install dftly`
 
+To enable the optional polars execution engine, install with the extra:
+
+```bash
+pip install "dftly[polars]"
+```
+
 ## Usage
 
 To parse a YAML mapping of output columns to operations, use `dftly.from_yaml`:
@@ -32,6 +38,17 @@ defined in `src/dftly/grammar.lark`, making the
 implementation extensible beyond the simple examples shown above.
 
 The returned object contains instances of `dftly.Expression`, `dftly.Column`, and `dftly.Literal` representing the fully resolved operations.
+
+If `polars` is installed, you can convert these resolved operations to `polars` expressions:
+
+```python
+import polars as pl
+from dftly.polars import to_polars
+
+df = pl.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+expr = to_polars(result["a"])
+df = df.with_columns(a=expr)
+```
 
 ## Design Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = ["PyYAML", "lark", "python-dateutil"]
 # Development dependencies
 dev = ["pre-commit<4", "ruff"]
 tests = ["pytest", "pytest-cov"]
+polars = ["polars"]
 
 [project.urls]
 Homepage = "https://github.com/mmcdermott/dftly"

--- a/src/dftly/polars.py
+++ b/src/dftly/polars.py
@@ -1,0 +1,94 @@
+"""Polars execution engine for dftly."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+try:
+    import polars as pl
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ModuleNotFoundError(
+        "Polars is required for the dftly.polars module. Install with 'dftly[polars]'"
+    ) from exc
+
+from .nodes import Column, Expression, Literal
+
+
+_TYPE_MAP: dict[str, Any] = {
+    "int": int,
+    "integer": int,
+    "float": float,
+    "double": float,
+    "bool": bool,
+    "boolean": bool,
+    "str": str,
+    "string": str,
+    "date": pl.Date,
+    "datetime": pl.Datetime,
+}
+
+
+def to_polars(node: Any) -> pl.Expr:
+    """Convert a dftly node to a polars expression."""
+    if isinstance(node, Literal):
+        return pl.lit(node.value)
+    if isinstance(node, Column):
+        return pl.col(node.name)
+    if isinstance(node, Expression):
+        return _expr_to_polars(node)
+    raise TypeError(f"Unsupported node type: {type(node).__name__}")
+
+
+def map_to_polars(mapping: Mapping[str, Any]) -> Dict[str, pl.Expr]:
+    """Convert a mapping of dftly nodes to polars expressions."""
+    return {k: to_polars(v) for k, v in mapping.items()}
+
+
+def _expr_to_polars(expr: Expression) -> pl.Expr:
+    typ = expr.type.upper()
+    args = expr.arguments
+
+    if typ == "ADD":
+        return sum(to_polars(arg) for arg in args)
+    if typ == "SUBTRACT":
+        left, right = args
+        return to_polars(left) - to_polars(right)
+    if typ == "TYPE_CAST":
+        inp = to_polars(args["input"])
+        out_type = args["output_type"].value
+        dtype = _TYPE_MAP.get(out_type.lower(), out_type)
+        return inp.cast(dtype)
+    if typ == "CONDITIONAL":
+        return (
+            pl.when(to_polars(args["if"]))
+            .then(to_polars(args["then"]))
+            .otherwise(to_polars(args["else"]))
+        )
+    if typ == "RESOLVE_TIMESTAMP":
+        return _resolve_timestamp(args)
+
+    raise ValueError(f"Unsupported expression type: {expr.type}")
+
+
+def _resolve_timestamp(args: Mapping[str, Any]) -> pl.Expr:
+    date = args["date"]
+    time = args["time"]
+
+    if isinstance(date, Mapping):
+        year = to_polars(date["year"])
+        month = to_polars(date["month"])
+        day = to_polars(date["day"])
+    else:
+        date_expr = to_polars(date)
+        year = date_expr.dt.year()
+        month = date_expr.dt.month()
+        day = date_expr.dt.day()
+
+    hour = to_polars(time["hour"])
+    minute = to_polars(time["minute"])
+    second = to_polars(time["second"])
+
+    return pl.datetime(year, month, day, hour, minute, second)
+
+
+__all__ = ["to_polars", "map_to_polars"]

--- a/tests/test_polars_engine.py
+++ b/tests/test_polars_engine.py
@@ -1,9 +1,3 @@
-import pytest
-
-# allow pytest.importorskip before importing polars
-# ruff: noqa: E402
-
-polars = pytest.importorskip("polars")
 import polars as pl
 
 from dftly import from_yaml

--- a/tests/test_polars_engine.py
+++ b/tests/test_polars_engine.py
@@ -1,0 +1,67 @@
+import pytest
+
+# allow pytest.importorskip before importing polars
+# ruff: noqa: E402
+
+polars = pytest.importorskip("polars")
+import polars as pl
+
+from dftly import from_yaml
+from dftly.polars import to_polars
+
+
+def test_polars_addition():
+    text = "a: col1 + col2"
+    result = from_yaml(text, input_schema={"col1": "int", "col2": "int"})
+    expr = to_polars(result["a"])
+
+    df = pl.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    out = df.with_columns(a=expr).get_column("a")
+    assert out.to_list() == [4, 6]
+
+
+def test_polars_subtract():
+    text = "a: col1 - col2"
+    result = from_yaml(text, input_schema={"col1": "int", "col2": "int"})
+    expr = to_polars(result["a"])
+
+    df = pl.DataFrame({"col1": [5, 10], "col2": [3, 4]})
+    out = df.with_columns(a=expr).get_column("a")
+    assert out.to_list() == [2, 6]
+
+
+def test_polars_type_cast():
+    text = "a: col1 as float"
+    result = from_yaml(text, input_schema={"col1": "int"})
+    expr = to_polars(result["a"])
+
+    df = pl.DataFrame({"col1": [1, 2]})
+    out = df.with_columns(a=expr).get_column("a")
+    assert out.dtype == pl.Float64
+
+
+def test_polars_conditional():
+    text = "a: col1 if flag else col2"
+    schema = {"col1": "int", "col2": "int", "flag": "bool"}
+    result = from_yaml(text, input_schema=schema)
+    expr = to_polars(result["a"])
+
+    df = pl.DataFrame({"col1": [1, 2], "col2": [3, 4], "flag": [True, False]})
+    out = df.with_columns(a=expr).get_column("a")
+    assert out.to_list() == [1, 4]
+
+
+def test_polars_resolve_timestamp():
+    text = """
+    a: charttime @ 11:59:59 p.m.
+    """
+    schema = {"charttime": "date"}
+    result = from_yaml(text, input_schema=schema)
+    expr = to_polars(result["a"])
+
+    from datetime import date
+
+    df = pl.DataFrame({"charttime": [date(2020, 1, 1), date(2021, 1, 1)]})
+    out = df.with_columns(a=expr).get_column("a")
+    assert out[0].hour == 23 and out[0].minute == 59 and out[0].second == 59
+    assert out[1].hour == 23 and out[1].minute == 59 and out[1].second == 59


### PR DESCRIPTION
## Summary
- support converting fully resolved nodes to polars expressions
- expose optional `polars` submodule
- document extra installation and give usage example in README
- test polars translation
- run tests without polars and then again with polars in CI
- fix polars type casting mapping
- add tests for subtract, casting and conditional expressions
- remove unnecessary optional polars import

## Testing
- `pre-commit run --files src/dftly/__init__.py src/dftly/polars.py tests/test_polars_engine.py README.md .github/workflows/tests.yaml`
- `pytest -q`
- `pip install polars -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687925ce8874832c80de50b7d8ef97a9