### PR TITLE
Fix ADD expression and add datetime+duration test

### DIFF
--- a/src/dftly/polars.py
+++ b/src/dftly/polars.py
@@ -49,7 +49,10 @@ def _expr_to_polars(expr: Expression) -> pl.Expr:
     args = expr.arguments
 
     if typ == "ADD":
-        return sum(to_polars(arg) for arg in args)
+        expr = to_polars(args[0])
+        for arg in args[1:]:
+            expr = expr + to_polars(arg)
+        return expr
     if typ == "SUBTRACT":
         left, right = args
         return to_polars(left) - to_polars(right)

--- a/tests/test_polars_engine.py
+++ b/tests/test_polars_engine.py
@@ -14,6 +14,27 @@ def test_polars_addition():
     assert out.to_list() == [4, 6]
 
 
+def test_polars_datetime_plus_duration():
+    text = "a: dt + dur"
+    result = from_yaml(text, input_schema={"dt": "datetime", "dur": "duration"})
+    expr = to_polars(result["a"])
+
+    from datetime import datetime, timedelta
+
+    df = pl.DataFrame(
+        {
+            "dt": [
+                datetime(2024, 1, 1, 1, 0, 0),
+                datetime(2024, 1, 1, 2, 0, 0),
+            ],
+            "dur": [timedelta(minutes=30), timedelta(minutes=45)],
+        }
+    )
+    out = df.with_columns(a=expr).get_column("a")
+    assert out[0] == datetime(2024, 1, 1, 1, 30, 0)
+    assert out[1] == datetime(2024, 1, 1, 2, 45, 0)
+
+
 def test_polars_subtract():
     text = "a: col1 - col2"
     result = from_yaml(text, input_schema={"col1": "int", "col2": "int"})


### PR DESCRIPTION
## Summary
- remove use of `sum()` in Polars conversion for ADD expressions
- ensure datetime addition with a duration works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6b10e16c832c804110725309ec51