### PR TITLE
Support function-call syntax

### DIFF
--- a/src/dftly/grammar.lark
+++ b/src/dftly/grammar.lark
@@ -27,5 +27,9 @@ op: PLUS cast_expr     -> plus
   | MINUS cast_expr    -> minus
 ?at_expr: cast_expr AT cast_expr   -> resolve_ts
         | cast_expr
-cast_expr: NAME AS NAME   -> cast
+cast_expr: call_expr
+         | NAME AS NAME   -> cast
          | NAME           -> name
+
+call_expr: NAME "(" [args] ")"   -> func
+args: expr ("," expr)*   -> arg_list

--- a/src/dftly/parser.py
+++ b/src/dftly/parser.py
@@ -278,6 +278,19 @@ class DftlyTransformer(Transformer):
             },
         )
 
+    def cast_expr(self, items: list[Any]) -> Any:  # type: ignore[override]
+        (item,) = items
+        return item
+
+    def arg_list(self, items: list[Any]) -> list[Any]:  # type: ignore[override]
+        return items
+
+    def func(self, items: list[Any]) -> Expression:  # type: ignore[override]
+        name = items[0]
+        args = items[1] if len(items) > 1 else []
+        parsed_args = [self.parser._as_node(a) for a in args]
+        return Expression(name.upper(), parsed_args)
+
     def plus(self, items: list[Any]) -> Tuple[str, Any]:  # type: ignore[override]
         _, val = items
         return "+", val

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -16,6 +16,18 @@ def test_parse_addition():
     assert args[1].name == "col2"
 
 
+def test_parse_function_call():
+    text = "a: add(col1, col2)"
+    result = from_yaml(text, input_schema={"col1": "int", "col2": "int"})
+    expr = result["a"]
+    assert isinstance(expr, Expression)
+    assert expr.type == "ADD"
+    args = expr.arguments
+    assert isinstance(args, list) and len(args) == 2
+    assert isinstance(args[0], Column) and args[0].name == "col1"
+    assert isinstance(args[1], Column) and args[1].name == "col2"
+
+
 def test_parse_literal_string():
     text = "a: hello"
     result = from_yaml(text)

--- a/tests/test_polars_engine.py
+++ b/tests/test_polars_engine.py
@@ -14,6 +14,16 @@ def test_polars_addition():
     assert out.to_list() == [4, 6]
 
 
+def test_polars_function_call():
+    text = "a: add(col1, col2)"
+    result = from_yaml(text, input_schema={"col1": "int", "col2": "int"})
+    expr = to_polars(result["a"])
+
+    df = pl.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    out = df.with_columns(a=expr).get_column("a")
+    assert out.to_list() == [4, 6]
+
+
 def test_polars_datetime_plus_duration():
     text = "a: dt + dur"
     result = from_yaml(text, input_schema={"dt": "datetime", "dur": "duration"})


### PR DESCRIPTION
## Summary
- extend grammar to parse function call syntax like `NAME(args)`
- produce `Expression(NAME.upper(), parsed_args)` when parsing these calls
- test parsing and polars conversion via `add(col1, col2)`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ed46f8a8832cb7ca80eb1020aeb9