### PR TITLE
Add membership operator parsing

### DIFF
--- a/src/dftly/grammar.lark
+++ b/src/dftly/grammar.lark
@@ -11,6 +11,8 @@ AND.2: "and"i
 OR.2: "or"i
 NOT.2: "not"i
 NAME: /[A-Za-z_][A-Za-z0-9_]*/
+IN: /in/i
+NUMBER: /\d+(?:\.\d+)?/
 
 start: expr
 expr: conditional
@@ -18,7 +20,10 @@ conditional: bool_expr IF bool_expr ELSE conditional   -> ifexpr
           | bool_expr
 
 ?bool_expr: and_expr (OR and_expr)*   -> or_expr
-?and_expr: unary (AND unary)*         -> and_expr
+?and_expr: in_expr (AND in_expr)*     -> and_expr
+?in_expr: unary IN set_literal        -> value_in_set
+        | unary IN range_literal      -> value_in_range
+        | unary
 ?unary: NOT unary                    -> not_expr
       | additive
 
@@ -29,7 +34,15 @@ op: PLUS cast_expr     -> plus
         | cast_expr
 cast_expr: call_expr
          | NAME AS NAME   -> cast
+         | NUMBER         -> number
          | NAME           -> name
 
 call_expr: NAME "(" [args] ")"   -> func
 args: expr ("," expr)*   -> arg_list
+
+set_literal: "{" [args] "}"   -> literal_set
+
+range_literal: "[" expr "," expr "]"   -> range_inc
+             | "[" expr "," expr ")"   -> range_ie
+             | "(" expr "," expr "]"   -> range_ei
+             | "(" expr "," expr ")"   -> range_exc

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -165,6 +165,28 @@ def test_parse_value_in_set_and_range():
     assert in_range.type == "VALUE_IN_RANGE"
 
 
+def test_parse_in_operator_string_forms():
+    text = """
+    a: col1 in {1, 2}
+    b: col1 in (0, 2]
+    """
+    result = from_yaml(text, input_schema={"col1": "int"})
+
+    in_set = result["a"]
+    assert isinstance(in_set, Expression)
+    assert in_set.type == "VALUE_IN_LITERAL_SET"
+    vals = in_set.arguments["set"]
+    assert all(isinstance(v, Literal) for v in vals)
+    assert [v.value for v in vals] == [1, 2]
+
+    in_range = result["b"]
+    assert isinstance(in_range, Expression)
+    assert in_range.type == "VALUE_IN_RANGE"
+    args = in_range.arguments
+    assert args["min_inclusive"].value is False
+    assert args["max_inclusive"].value is True
+
+
 def test_parse_fully_resolved_forms():
     text = """
     a:

--- a/tests/test_polars_engine.py
+++ b/tests/test_polars_engine.py
@@ -138,6 +138,21 @@ def test_polars_boolean_and_coalesce_and_membership():
     assert out.get_column("e").to_list() == [True, False]
 
 
+def test_polars_in_operator_string_forms():
+    text = """
+    a: col1 in {1, 3}
+    b: col1 in (0, 2]
+    """
+    result = from_yaml(text, input_schema={"col1": "int"})
+    df = pl.DataFrame({"col1": [1, 2, 3]})
+    out = df.with_columns(
+        a=to_polars(result["a"]),
+        b=to_polars(result["b"]),
+    )
+    assert out.get_column("a").to_list() == [True, False, True]
+    assert out.get_column("b").to_list() == [True, True, False]
+
+
 def test_polars_string_interpolate():
     text = """
     a:


### PR DESCRIPTION
## Summary
- extend grammar to parse `in` operator for sets and ranges
- update parser transformer with number, set, and range handling
- parse strings with `in` before string interpolation
- test parser and polars engine with `in` operator string forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813330c928832cb9ee7a8013002056