### PR TITLE
Support symbol boolean operators

### DIFF
--- a/src/dftly/grammar.lark
+++ b/src/dftly/grammar.lark
@@ -7,6 +7,9 @@ AT: "@"
 AS: /as/i
 IF: /if/i
 ELSE: /else/i
+AND_SYM: "&&"
+OR_SYM: "||"
+NOT_SYM: "!"
 AND.2: "and"i
 OR.2: "or"i
 NOT.2: "not"i
@@ -19,12 +22,12 @@ expr: conditional
 conditional: bool_expr IF bool_expr ELSE conditional   -> ifexpr
           | bool_expr
 
-?bool_expr: and_expr (OR and_expr)*   -> or_expr
-?and_expr: in_expr (AND in_expr)*     -> and_expr
+?bool_expr: and_expr ((OR|OR_SYM) and_expr)*   -> or_expr
+?and_expr: in_expr ((AND|AND_SYM) in_expr)*     -> and_expr
 ?in_expr: unary IN set_literal        -> value_in_set
         | unary IN range_literal      -> value_in_range
         | unary
-?unary: NOT unary                    -> not_expr
+?unary: (NOT|NOT_SYM) unary                    -> not_expr
       | additive
 
 additive: at_expr op*

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -141,6 +141,28 @@ def test_parse_boolean_and_coalesce():
     assert coalesce_expr.type == "COALESCE"
 
 
+def test_parse_boolean_symbol_forms():
+    text = """
+    a: flag1 && flag2
+    b: flag1 || flag2
+    c: "!flag1"
+    """
+    schema = {"flag1": "bool", "flag2": "bool"}
+    result = from_yaml(text, input_schema=schema)
+
+    and_expr = result["a"]
+    assert isinstance(and_expr, Expression)
+    assert and_expr.type == "AND"
+
+    or_expr = result["b"]
+    assert isinstance(or_expr, Expression)
+    assert or_expr.type == "OR"
+
+    not_expr = result["c"]
+    assert isinstance(not_expr, Expression)
+    assert not_expr.type == "NOT"
+
+
 def test_parse_value_in_set_and_range():
     text = """
     a:

--- a/tests/test_polars_engine.py
+++ b/tests/test_polars_engine.py
@@ -138,6 +138,25 @@ def test_polars_boolean_and_coalesce_and_membership():
     assert out.get_column("e").to_list() == [True, False]
 
 
+def test_polars_boolean_symbol_forms():
+    text = """
+    a: flag1 && flag2
+    b: flag1 || flag2
+    c: "!flag1"
+    """
+    schema = {"flag1": "bool", "flag2": "bool"}
+    result = from_yaml(text, input_schema=schema)
+    df = pl.DataFrame({"flag1": [True, False], "flag2": [True, True]})
+    out = df.with_columns(
+        a=to_polars(result["a"]),
+        b=to_polars(result["b"]),
+        c=to_polars(result["c"]),
+    )
+    assert out.get_column("a").to_list() == [True, False]
+    assert out.get_column("b").to_list() == [True, True]
+    assert out.get_column("c").to_list() == [False, True]
+
+
 def test_polars_in_operator_string_forms():
     text = """
     a: col1 in {1, 3}


### PR DESCRIPTION
## Summary
- extend grammar to accept `!`, `&&`, `||`
- ensure parser recognizes the new tokens
- test symbol forms for parsing and Polars evaluation

## Testing
- `pre-commit run --files src/dftly/grammar.lark tests/test_parser.py tests/test_polars_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814824c9fc832ca2e15e3c20e5d096