### PR TITLE
Add tests for non-mapping inputs

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -424,3 +424,15 @@ def test_parse_hash_to_int_and_hash_forms():
 
     alg = result["a"].arguments["algorithm"]
     assert isinstance(alg, Literal) and alg.value == "md5"
+
+
+def test_from_yaml_non_mapping_raises_type_error():
+    with pytest.raises(TypeError):
+        from_yaml("- 1\n- 2")
+
+
+def test_parse_non_mapping_raises_type_error():
+    from dftly import parse
+
+    with pytest.raises(TypeError):
+        parse([1, 2])


### PR DESCRIPTION
## Summary
- test that `from_yaml` raises a `TypeError` when YAML does not produce a mapping
- test that `parse` raises a `TypeError` with non-mapping input

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882390b9188832c891096d5f6eb9d04