### PR TITLE
Enable quoted strings and parentheses in expressions

### DIFF
--- a/src/dftly/grammar.lark
+++ b/src/dftly/grammar.lark
@@ -1,4 +1,5 @@
 %import common.WS
+%import common.ESCAPED_STRING -> STRING
 %ignore WS
 
 PLUS: "+"
@@ -16,6 +17,8 @@ NOT.2: "not"i
 NAME: /[A-Za-z_][A-Za-z0-9_]*/
 IN: /in/i
 NUMBER: /\d+(?:\.\d+)?/
+LPAR: "("
+RPAR: ")"
 
 start: expr
 expr: conditional
@@ -38,7 +41,9 @@ op: PLUS cast_expr     -> plus
 cast_expr: call_expr
          | NAME AS NAME   -> cast
          | NUMBER         -> number
+         | STRING         -> string
          | NAME           -> name
+         | "(" expr ")" -> paren_expr
 
 call_expr: NAME "(" [args] ")"   -> func
 args: expr ("," expr)*   -> arg_list

--- a/src/dftly/parser.py
+++ b/src/dftly/parser.py
@@ -415,6 +415,7 @@ class DftlyTransformer(Transformer):
 
     def string(self, items: list[str]) -> Literal:  # type: ignore[override]
         import ast
+
         (text,) = items
         return Literal(ast.literal_eval(text))
 

--- a/src/dftly/parser.py
+++ b/src/dftly/parser.py
@@ -398,6 +398,9 @@ class DftlyTransformer(Transformer):
     def NUMBER(self, token: Any) -> str:  # type: ignore[override]
         return str(token)
 
+    def STRING(self, token: Any) -> str:  # type: ignore[override]
+        return str(token)
+
     def number(self, items: list[str]) -> Literal:  # type: ignore[override]
         (text,) = items
         if "." in text:
@@ -409,6 +412,15 @@ class DftlyTransformer(Transformer):
     def name(self, items: list[str]) -> str:  # type: ignore[override]
         (val,) = items
         return val
+
+    def string(self, items: list[str]) -> Literal:  # type: ignore[override]
+        import ast
+        (text,) = items
+        return Literal(ast.literal_eval(text))
+
+    def paren_expr(self, items: list[Any]) -> Any:  # type: ignore[override]
+        (item,) = items
+        return item
 
     def expr(self, items: list[Any]) -> Any:  # type: ignore[override]
         (item,) = items

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -36,6 +36,17 @@ def test_parse_literal_string():
     assert lit.value == "hello"
 
 
+def test_parse_parentheses_and_string_literal():
+    text = 'a: (add(col1, "foo"))'
+    result = from_yaml(text, input_schema={"col1": "str"})
+    expr = result["a"]
+    assert isinstance(expr, Expression)
+    assert expr.type == "ADD"
+    args = expr.arguments
+    assert isinstance(args[0], Column)
+    assert isinstance(args[1], Literal) and args[1].value == "foo"
+
+
 def test_parse_string_interpolate_dict_and_string_forms():
     text = """
     a:


### PR DESCRIPTION
## Summary
- update grammar to support grouped expressions and string literals
- extend transformer for new tokens
- add parser test for parentheses and quoted strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c320d3a0832cb44b79ba837057f6