### PR TITLE
Support 'expr AS STRING' parse rule

### DIFF
--- a/src/dftly/grammar.lark
+++ b/src/dftly/grammar.lark
@@ -1,6 +1,6 @@
 %import common.WS
-%import common.ESCAPED_STRING -> STRING
 %ignore WS
+STRING: /'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"/
 
 PLUS: "+"
 MINUS: "-"
@@ -21,8 +21,10 @@ LPAR: "("
 RPAR: ")"
 
 start: expr
-expr: conditional
-conditional: bool_expr IF bool_expr ELSE conditional   -> ifexpr
+expr: parse_format
+parse_format: conditional AS STRING -> parse_as_format
+            | conditional
+conditional: bool_expr IF bool_expr ELSE parse_format   -> ifexpr
           | bool_expr
 
 ?bool_expr: and_expr ((OR|OR_SYM) and_expr)*   -> or_expr
@@ -39,6 +41,7 @@ op: PLUS cast_expr     -> plus
 ?at_expr: cast_expr AT cast_expr   -> resolve_ts
         | cast_expr
 cast_expr: call_expr
+         | NAME AS STRING  -> parse_as_format
          | NAME AS NAME   -> cast
          | NUMBER         -> number
          | STRING         -> string

--- a/src/dftly/parser.py
+++ b/src/dftly/parser.py
@@ -202,18 +202,6 @@ class Parser:
         if regex_expr is not None:
             return regex_expr
 
-        parse_fmt = re.match(r"(?i)^(.+)\s+as\s+(['\"])(.+)\2$", value.strip())
-        if parse_fmt:
-            input_text = parse_fmt.group(1).strip()
-            fmt = parse_fmt.group(3)
-            inp = self._parse_string(input_text)
-            out_type = self._infer_output_type(fmt)
-            args = {
-                "input": self._as_node(inp),
-                "format": Literal(fmt),
-                "output_type": Literal(out_type),
-            }
-            return Expression("PARSE_WITH_FORMAT_STRING", args)
 
         parse_failed = False
         try:
@@ -521,6 +509,25 @@ class DftlyTransformer(Transformer):
     def minus(self, items: list[Any]) -> Tuple[str, Any]:  # type: ignore[override]
         _, val = items
         return "-", val
+
+    def parse_as_format(self, items: list[Any]) -> Expression:  # type: ignore[override]
+        expr, _, fmt = items
+        fmt_text = fmt
+        if isinstance(fmt_text, str):
+            import ast
+
+            fmt_text = ast.literal_eval(fmt_text)
+        out_type = self.parser._infer_output_type(fmt_text)
+        args = {
+            "input": self.parser._as_node(expr),
+            "format": Literal(fmt_text),
+            "output_type": Literal(out_type),
+        }
+        return Expression("PARSE_WITH_FORMAT_STRING", args)
+
+    def parse_format(self, items: list[Any]) -> Any:  # type: ignore[override]
+        (item,) = items
+        return item
 
     def additive(self, items: list[Any]) -> Any:  # type: ignore[override]
         base = self.parser._as_node(items[0])


### PR DESCRIPTION
## Summary
- extend grammar to parse expressions of the form `expr AS STRING`
- implement transformer handling for `parse_as_format`
- allow single and double quoted strings in grammar
- drop regex-based `AS` parsing from the string parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c851d380832c8eb3558acc88adb6