### PR TITLE
Refactor timestamp handling

### DIFF
--- a/tests/test_integration_polars.py
+++ b/tests/test_integration_polars.py
@@ -38,7 +38,7 @@ d:
     value: col1
     min: 0
     max: 10
-e: chartdate @ 11:59:59 p.m.
+e: chartdate @ "11:59:59 p.m."
 """
 
 SCHEMA = {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -95,8 +95,8 @@ def test_parse_subtract_and_cast_and_conditional():
 
 def test_parse_resolve_timestamp_string_form():
     text = """
-    a: charttime @ 11:59:59 p.m.
-    b: birth_year @ January 1, 12:00 a.m.
+    a: charttime @ "11:59:59 p.m."
+    b: birth_year @ "January 1, 12:00 a.m."
     """
     schema = {"charttime": "date", "birth_year": "int"}
     result = from_yaml(text, input_schema=schema)

--- a/tests/test_polars_engine.py
+++ b/tests/test_polars_engine.py
@@ -78,7 +78,7 @@ def test_polars_conditional():
 
 def test_polars_resolve_timestamp():
     text = """
-    a: charttime @ 11:59:59 p.m.
+    a: charttime @ "11:59:59 p.m."
     """
     schema = {"charttime": "date"}
     result = from_yaml(text, input_schema=schema)


### PR DESCRIPTION
## Summary
- drop pre-Lark `@` parsing in `_parse_string`
- update `_parse_resolve_timestamp` to accept left/right values
- delegate `resolve_ts` transformer to the new helper
- quote timestamp strings in tests

## Testing
- `pre-commit run --files src/dftly/parser.py tests/test_parser.py tests/test_integration_polars.py tests/test_polars_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ecb9007c832c95ea67599a3c571c