### PR TITLE
Fix grammar precedence and add grouping rule

### DIFF
--- a/src/dftly/grammar.lark
+++ b/src/dftly/grammar.lark
@@ -30,34 +30,45 @@ MATCH.2: /match/i
 AGAINST.2: /against/i
 
 start: expr
-expr: parse_format
-parse_format: conditional AS STRING -> parse_as_format
-            | conditional
-conditional: bool_expr IF bool_expr ELSE parse_format   -> ifexpr
-          | bool_expr
 
-?bool_expr: and_expr ((OR|OR_SYM) and_expr)*   -> or_expr
-?and_expr: in_expr ((AND|AND_SYM) in_expr)*     -> and_expr
-?in_expr: unary IN set_literal        -> value_in_set
-        | unary IN range_literal      -> value_in_range
-        | unary
-?unary: (NOT|NOT_SYM) unary                    -> not_expr
-      | additive
+?expr: conditional
 
-additive: at_expr op*
-op: PLUS cast_expr     -> plus
-  | MINUS cast_expr    -> minus
-?at_expr: cast_expr AT cast_expr   -> resolve_ts
-        | cast_expr
-cast_expr: call_expr
-         | regex_extract
-         | regex_match
-         | NAME AS STRING  -> parse_as_format
-         | NAME AS NAME   -> cast
-         | NUMBER         -> number
-         | STRING         -> string
-         | NAME           -> name
-         | "(" expr ")" -> paren_expr
+conditional: bool_expr IF bool_expr ELSE expr   -> ifexpr
+           | bool_expr
+
+?bool_expr: bool_expr (OR|OR_SYM) bool_term   -> or_expr
+          | bool_term
+
+?bool_term: bool_term (AND|AND_SYM) bool_factor   -> and_expr
+          | bool_factor
+
+?bool_factor: (NOT|NOT_SYM) bool_factor       -> not_expr
+            | in_expr
+
+?in_expr: additive IN set_literal        -> value_in_set
+        | additive IN range_literal      -> value_in_range
+        | additive
+
+?additive: additive PLUS multiplicative
+         | additive MINUS multiplicative
+         | multiplicative
+
+?multiplicative: multiplicative AT unary  -> resolve_ts
+               | unary
+
+?unary: primary
+
+primary: call_expr
+       | regex_extract
+       | regex_match
+       | NAME AS STRING  -> parse_as_format
+       | NAME AS NAME   -> cast
+       | NUMBER         -> number
+       | STRING         -> string
+       | NAME           -> name
+       | group
+
+group: "(" expr ")" -> paren_expr
 
 call_expr: NAME "(" [args] ")"   -> func
 args: expr ("," expr)*   -> arg_list

--- a/tests/test_polars_engine.py
+++ b/tests/test_polars_engine.py
@@ -157,6 +157,43 @@ def test_polars_boolean_symbol_forms():
     assert out.get_column("c").to_list() == [False, True]
 
 
+def test_polars_nested_parentheses_operations():
+    text = """
+    a: (col1 + col2) - (col3 + col4)
+    b: flag1 and (flag2 or flag3)
+    c: not (flag1 or flag2)
+    """
+    schema = {
+        "col1": "int",
+        "col2": "int",
+        "col3": "int",
+        "col4": "int",
+        "flag1": "bool",
+        "flag2": "bool",
+        "flag3": "bool",
+    }
+    result = from_yaml(text, input_schema=schema)
+    df = pl.DataFrame(
+        {
+            "col1": [1, 2],
+            "col2": [3, 4],
+            "col3": [5, 6],
+            "col4": [7, 8],
+            "flag1": [True, False],
+            "flag2": [False, True],
+            "flag3": [True, False],
+        }
+    )
+    out = df.with_columns(
+        a=to_polars(result["a"]),
+        b=to_polars(result["b"]),
+        c=to_polars(result["c"]),
+    )
+    assert out.get_column("a").to_list() == [-8, -8]
+    assert out.get_column("b").to_list() == [True, False]
+    assert out.get_column("c").to_list() == [False, False]
+
+
 def test_polars_in_operator_string_forms():
     text = """
     a: col1 in {1, 3}


### PR DESCRIPTION
## Summary
- overhaul grammar to use proper operator precedence
- update parser transformer methods for new rule names
- handle names as nodes directly
- test nested expressions with parentheses
- ensure pre-commit and tests run cleanly

## Testing
- `pre-commit run --all`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a38d19890832c945a8f71e1ae94eb