### PR TITLE
Add explicit column syntax and schema validation

### DIFF
--- a/src/dftly/__init__.py
+++ b/src/dftly/__init__.py
@@ -2,6 +2,7 @@
 
 from .nodes import Column, Expression, Literal
 from .parser import Parser, from_yaml, parse
+from .validation import SchemaValidationError, validate_schema
 
 __all__ = [
     "Column",
@@ -10,4 +11,6 @@ __all__ = [
     "Parser",
     "parse",
     "from_yaml",
+    "SchemaValidationError",
+    "validate_schema",
 ]

--- a/src/dftly/expressions/general.py
+++ b/src/dftly/expressions/general.py
@@ -344,10 +344,7 @@ class ParseWithFormatStringExpression(ExpressionNode):
             raise TypeError("PARSE_WITH_FORMAT_STRING arguments must be a mapping")
         normalized = cls._normalize(expr_type)
         if normalized not in {cls.type, *(cls._normalize(a) for a in cls.aliases)}:
-            parsed_args.setdefault(
-                "input",
-                Column(expr_type, parser.input_schema.get(expr_type)),
-            )
+            parsed_args.setdefault("input", Column(expr_type))
         cls._post_process_arguments(parsed_args)
         return Expression(cls.type, parsed_args)
 

--- a/src/dftly/grammar.lark
+++ b/src/dftly/grammar.lark
@@ -69,11 +69,16 @@ primary: call_expr
        | regex_extract
        | regex_match
        | NAME AS STRING  -> parse_as_format
+       | column_ref AS STRING  -> parse_as_format
        | NAME AS NAME   -> cast
+       | column_ref AS NAME   -> cast
        | NUMBER         -> number
        | STRING         -> string
        | NAME           -> name
+       | column_ref
        | group
+
+column_ref: AT NAME
 
 group: "(" expr ")" -> paren_expr
 

--- a/src/dftly/nodes.py
+++ b/src/dftly/nodes.py
@@ -93,21 +93,19 @@ class Column(NodeBase):
     def _validate_map(
         cls,
         value: Any,
-        *,
-        input_schema: Optional[Mapping[str, Optional[str]]] = None,
     ) -> Mapping[str, Any]:
         if isinstance(value, str):
-            typ = None if input_schema is None else input_schema.get(value)
-            return {"name": value, "type": typ}
+            return {"name": value}
         if isinstance(value, Mapping):
             cls._validate_keys(
                 value, {"name", "type"}, label="column", required={"name"}
             )
             name = value["name"]
             typ = value.get("type")
-            if typ is None and input_schema is not None:
-                typ = input_schema.get(name)
-            return {"name": name, "type": typ}
+            data = {"name": name}
+            if typ is not None:
+                data["type"] = typ
+            return data
         raise TypeError("column value must be a string or mapping")
 
 

--- a/src/dftly/validation.py
+++ b/src/dftly/validation.py
@@ -1,0 +1,78 @@
+"""Schema validation utilities for parsed dftly trees."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from .nodes import Column, Expression
+
+
+class SchemaValidationError(ValueError):
+    """Raised when parsed nodes are incompatible with a provided schema."""
+
+
+def validate_schema(parsed: Any, schema: Mapping[str, Any]) -> None:
+    """Validate that all column references exist in the provided schema.
+
+    Parameters
+    ----------
+    parsed:
+        A parsed node or mapping of nodes produced by :func:`dftly.parse`
+        or :func:`dftly.from_yaml`.
+    schema:
+        Mapping of column names to optional type strings.
+    """
+
+    if not isinstance(schema, Mapping):
+        raise TypeError("schema must be a mapping of column names to types")
+
+    _validate_node(parsed, schema, path=())
+
+
+def _validate_node(node: Any, schema: Mapping[str, Any], path: Sequence[str]) -> None:
+    if isinstance(node, Column):
+        _validate_column(node, schema, path)
+        return
+
+    if isinstance(node, Expression):
+        _validate_node(node.arguments, schema, (*path, f"expression:{node.type}"))
+        return
+
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            _validate_node(value, schema, (*path, str(key)))
+        return
+
+    if isinstance(node, Sequence) and not isinstance(node, (str, bytes, bytearray)):
+        for index, value in enumerate(node):
+            _validate_node(value, schema, (*path, str(index)))
+        return
+
+
+def _validate_column(column: Column, schema: Mapping[str, Any], path: Sequence[str]) -> None:
+    if column.name not in schema:
+        location = _format_path(path)
+        raise SchemaValidationError(
+            f"Unknown column '{column.name}' referenced at {location}"
+        )
+
+    expected_type = schema[column.name]
+    if expected_type is None:
+        return
+
+    if column.type is None:
+        column.type = expected_type
+        return
+
+    if column.type != expected_type:
+        location = _format_path(path)
+        raise SchemaValidationError(
+            f"Column '{column.name}' at {location} expected type {expected_type!r}"
+            f" but found {column.type!r}"
+        )
+
+
+def _format_path(path: Sequence[str]) -> str:
+    if not path:
+        return "<root>"
+    return " -> ".join(path)

--- a/tests/test_integration_polars.py
+++ b/tests/test_integration_polars.py
@@ -1,7 +1,7 @@
 import io
 import polars as pl
 from datetime import datetime
-from dftly import from_yaml
+from dftly import from_yaml, validate_schema
 from dftly.polars import map_to_polars
 
 
@@ -21,24 +21,24 @@ a:
       - {literal: 2}
       - {column: col2}
 b:
-  - col3
+  - "@col3"
   - {literal: 3}
 c:
   conditional:
-    if: flag
+    if: "@flag"
     then:
       expression:
         type: SUBTRACT
         arguments:
-          - col1
+          - "@col1"
           - 1
-    else: col2
+    else: "@col2"
 d:
   value_in_range:
-    value: col1
+    value: "@col1"
     min: 0
     max: 10
-e: chartdate @ "11:59:59 p.m."
+e: @chartdate @ "11:59:59 p.m."
 """
 
 SCHEMA = {
@@ -55,7 +55,8 @@ def test_polars_integration_complex_csv_yaml():
         io.StringIO(CSV_TEXT),
         schema_overrides={"flag": pl.Boolean, "chartdate": pl.Date},
     )
-    result = from_yaml(YAML_TEXT, input_schema=SCHEMA)
+    result = from_yaml(YAML_TEXT)
+    validate_schema(result, SCHEMA)
     exprs = map_to_polars(result)
     out = df.with_columns(**exprs)
 


### PR DESCRIPTION
## Summary
- remove the parser input_schema parameter and require explicit column syntax via `@name` or `col()`
- add a post-parse `validate_schema` helper that populates column types and checks schema compatibility
- update grammar, tests, and documentation to exercise the new syntax and describe the migration path

## Testing
- pytest *(fails: optional polars dependency is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e654dacee4832ca470cd765e0dc31d