### PR TITLE
Refine regex extract syntax and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,29 @@ shape: (2, 3)
 └─────┴──────┴─────────┘
 
 ```
+
+Regex extraction can be expressed either through YAML mappings or the string DSL:
+
+```python
+>>> bp_ops = {
+...     "systolic": {
+...         "regex_extract": {
+...             "from": {"column": "bp"},
+...             "pattern": r"^(\d+)/(\d+)$",
+...         }
+...     },
+...     "diastolic": "extract group 2 of /^(\d+)\/(\d+)$/ from @bp",
+... }
+>>> bp_exprs = {name: parser(expr).polars_expr for name, expr in bp_ops.items()}
+>>> df.select(**bp_exprs)
+shape: (2, 2)
+┌──────────┬───────────┐
+│ systolic ┆ diastolic │
+│ ---      ┆ ---       │
+│ str      ┆ str       │
+╞══════════╪═══════════╡
+│ 120      ┆ 80        │
+│ null     ┆ null      │
+└──────────┴───────────┘
+
+```

--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -8,6 +8,7 @@ from .comparison import (
     GreaterThanOrEqual,
     LessThanOrEqual,
 )
+from .str import RegexExtract
 
 __nodes = [
     Literal,
@@ -22,6 +23,7 @@ __nodes = [
     NotEqual,
     GreaterThanOrEqual,
     LessThanOrEqual,
+    RegexExtract,
 ]
 
 NODES = {node.KEY: node for node in __nodes}

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -1,0 +1,125 @@
+from typing import Any
+
+import polars as pl
+
+from .base import Literal, NestedArgsNode, NodeBase
+
+
+class RegexExtract(NestedArgsNode):
+    """Extract a regex capture group from a string expression."""
+
+    KEY = "regex_extract"
+
+    def __post_init__(self) -> None:
+        normalized_kwargs = dict(self.kwargs)
+
+        if self.args:
+            if len(self.args) not in (2, 3):
+                raise ValueError(
+                    "regex_extract requires value, pattern, and optional group arguments"
+                )
+
+            value_node, pattern_node, *rest = self.args
+            normalized_kwargs.setdefault("from", value_node)
+            normalized_kwargs.setdefault("pattern", pattern_node)
+            if rest:
+                normalized_kwargs.setdefault("group", rest[0])
+
+            self.args = ()
+
+        pattern_node = normalized_kwargs.get("pattern")
+        if pattern_node is None:
+            raise ValueError("regex_extract requires a 'pattern' argument")
+        if isinstance(pattern_node, str):
+            pattern_node = Literal(pattern_node)
+        normalized_kwargs["pattern"] = pattern_node
+
+        if "group" in normalized_kwargs:
+            group_node = normalized_kwargs["group"]
+            if isinstance(group_node, int):
+                group_node = Literal(group_node)
+            normalized_kwargs["group"] = group_node
+
+        self.kwargs = normalized_kwargs
+
+        super().__post_init__()
+
+        try:
+            self._value_node = self.kwargs["from"]
+        except KeyError as exc:
+            raise ValueError("regex_extract requires a 'from' argument") from exc
+
+        pattern_literal = self.kwargs["pattern"]
+        if not isinstance(pattern_literal, Literal):
+            raise TypeError("regex_extract pattern must be provided as a literal")
+
+        self._pattern_value = pattern_literal.args[0]
+        if not isinstance(self._pattern_value, str):
+            raise TypeError("regex_extract pattern literal must be a string")
+
+        group_literal = self.kwargs.get("group")
+        if group_literal is None:
+            self._group_index = 1
+        else:
+            if not isinstance(group_literal, Literal):
+                raise TypeError("regex_extract group must be provided as a literal")
+            group_value = group_literal.args[0]
+            if not isinstance(group_value, int):
+                raise TypeError("regex_extract group literal must be an integer")
+            self._group_index = group_value
+
+    @property
+    def polars_expr(self) -> pl.Expr:
+        value_expr = self._value_node.polars_expr
+        return value_expr.str.extract(self._pattern_value, self._group_index)
+
+    @classmethod
+    def args_from_value(
+        cls, value: Any
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        args, kwargs = super().args_from_value(value)
+
+        normalized_kwargs = dict(kwargs)
+
+        if args:
+            if len(args) not in (2, 3):
+                raise ValueError(
+                    "regex_extract requires value, pattern, and optional group arguments"
+                )
+
+            normalized_kwargs.setdefault("from", args[0])
+            normalized_kwargs.setdefault("pattern", args[1])
+            if len(args) == 3:
+                normalized_kwargs.setdefault("group", args[2])
+
+        if "pattern" in normalized_kwargs and isinstance(normalized_kwargs["pattern"], str):
+            normalized_kwargs["pattern"] = {Literal.KEY: normalized_kwargs["pattern"]}
+
+        if "group" in normalized_kwargs and isinstance(normalized_kwargs["group"], int):
+            normalized_kwargs["group"] = {Literal.KEY: normalized_kwargs["group"]}
+
+        return (), normalized_kwargs
+
+    @classmethod
+    def from_lark(cls, items: Any) -> dict[str, Any]:
+        if isinstance(items, dict):
+            normalized = dict(items)
+        else:
+            values = list(items)
+            if len(values) not in (2, 3):
+                raise ValueError(
+                    "regex_extract requires value, pattern, and optional group arguments"
+                )
+            normalized = {"from": values[0], "pattern": values[1]}
+            if len(values) == 3:
+                normalized["group"] = values[2]
+
+        pattern_value = normalized.get("pattern")
+        if isinstance(pattern_value, str):
+            normalized["pattern"] = {Literal.KEY: pattern_value}
+
+        group_value = normalized.get("group")
+        if isinstance(group_value, int):
+            normalized["group"] = {Literal.KEY: group_value}
+
+        return {cls.KEY: normalized}

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -26,8 +26,7 @@ NOT.2: "not"i
 NAME: /[A-Za-z_][A-Za-z0-9_]*/
 IN: /in/i
 NUMBER: /\d+(?:\.\d+)?/
-REGEX_PAREN_TOKEN.2: /\([^\s]+\)/
-REGEX_TOKEN: /[^\s()]+/
+REGEX_LITERAL: /\/([^\/\\\n]|\\.)*\//
 LPAR: "("
 RPAR: ")"
 EXTRACT.2: /extract/i
@@ -52,13 +51,25 @@ AGAINST.2: /against/i
 
 ?unary: primary
 
-?primary: call_expr
+?primary: regex_extract_stmt
+       | call_expr
        | (AT)NAME -> column
        | NUMBER
        | STRING
        | group
 
 ?group: "(" expr ")"
+
+group_clause: GROUP expr -> group_clause
+
+regex_pattern: REGEX_LITERAL
+             | STRING
+
+regex_extract_simple: regex_pattern FROM expr -> regex_extract_simple
+regex_extract_grouped: group_clause OF regex_pattern FROM expr -> regex_extract_grouped
+
+?regex_extract_stmt: EXTRACT regex_extract_grouped -> regex_extract_stmt
+                    | EXTRACT regex_extract_simple -> regex_extract_stmt
 
 ?call_expr: NAME "(" [args] ")"   -> func
 ?args: expr ("," expr)*

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -65,6 +65,28 @@ class DftlyGrammar(Transformer):
         at_sign, column_name = items
         return Column.from_lark(column_name)
 
+    def REGEX_LITERAL(self, token: str) -> str:
+        pattern = token[1:-1]
+        return pattern.replace("\\/", "/")
+
+    def group_clause(self, items: list[Any]) -> Any:
+        return items[-1]
+
+    def regex_pattern(self, items: list[Any]) -> Any:
+        return items[0]
+
+    def regex_extract_simple(self, items: list[Any]) -> dict:
+        pattern, _, value = items
+        return {"pattern": pattern, "from": value}
+
+    def regex_extract_grouped(self, items: list[Any]) -> dict:
+        group, _, pattern, _, value = items
+        return {"pattern": pattern, "from": value, "group": group}
+
+    def regex_extract_stmt(self, items: list[Any]) -> dict:
+        params = items[-1]
+        return {"regex_extract": params}
+
     def binary_expr(self, items: list[dict | str]) -> dict:
         left, op, right = items
 


### PR DESCRIPTION
## Summary
- update the RegexExtract node to normalize keyword arguments and support literal pattern/group extraction
- extend the string grammar to parse `extract group … of /…/ from …` syntax using slash-delimited regex literals
- document the new usage in the README and drop the dedicated regression test file in favor of doctests
- rename the regex node module to `str.py` and harden slash literal parsing in the grammar transformer

## Testing
- pytest --doctest-glob=README.md
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68e7f9ceb9a0832c8eccb17f2cb63efc