### PR TITLE
Switch column string syntax to dollar prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ with dftly, we can write a yaml file like this:
 
 ```python
 >>> ops = r"""
-... sum: "@col1 + @col2"
-... diff: "@foo::int - @col1"
-... compare: "@col1 > (@col2 - 3) * 3"
-... str_interp: 'f"value: {@foo} {@col1}"'
-... max: "max(@col1, @col2)"
-... conditional: '"big" if @col1 > 1 else "small"'
-... sys_bp: "extract group 1 of /(\\d+)\\/(\\d+)/ from @bp if /(\\d+)\\/(\\d+)/ in @bp"
-... dia_bp: "(extract group 2 of /(\\d+)\\/(\\d+)/ from @bp if /(\\d+)\\/(\\d+)/ in @bp) as float"
+... sum: "$col1 + $col2"
+... diff: "$foo::int - $col1"
+... compare: "$col1 > ($col2 - 3) * 3"
+... str_interp: 'f"value: {$foo} {$col1}"'
+... max: "max($col1, $col2)"
+... conditional: '"big" if $col1 > 1 else "small"'
+... sys_bp: "extract group 1 of /(\\d+)\\/(\\d+)/ from $bp if /(\\d+)\\/(\\d+)/ in $bp"
+... dia_bp: "(extract group 2 of /(\\d+)\\/(\\d+)/ from $bp if /(\\d+)\\/(\\d+)/ in $bp) as float"
 ... """
 
 ```
@@ -97,8 +97,8 @@ more:
 
 ```python
 >>> ops = r"""
-... as_date: '@col3 as "%Y-%m-%d"'
-... days_later: '(@col3 as "%Y-%m-%d") + @col1::days'
+... as_date: '$col3 as "%Y-%m-%d"'
+... days_later: '($col3 as "%Y-%m-%d") + $col1::days'
 ... """
 >>> df.select(**Parser.to_polars(ops))
 shape: (2, 2)
@@ -121,14 +121,14 @@ the below is equivalent to the above:
 
 ```python
 >>> ops = {
-...     "sum": "@col1 + @col2",
-...     "diff": "@col2 - @col1",
-...     "compare": "@col1 > (@col2 - 3) * 3",
-...     "str_interp": 'f"value: {@foo} {@col1}"',
-...     "max": "max(@col1, @col2)",
-...     "conditional": '"big" if @col1 > 1 else "small"',
-...     "sys_bp": r"extract group 1 of /(\d+)\/(\d+)/ from @bp if /(\d+)\/(\d+)/ in @bp",
-...     "dia_bp": r"extract group 2 of /(\d+)\/(\d+)/ from @bp if /(\d+)\/(\d+)/ in @bp",
+...     "sum": "$col1 + $col2",
+...     "diff": "$col2 - $col1",
+...     "compare": "$col1 > ($col2 - 3) * 3",
+...     "str_interp": 'f"value: {$foo} {$col1}"',
+...     "max": "max($col1, $col2)",
+...     "conditional": '"big" if $col1 > 1 else "small"',
+...     "sys_bp": r"extract group 1 of /(\d+)\/(\d+)/ from $bp if /(\d+)\/(\d+)/ in $bp",
+...     "dia_bp": r"extract group 2 of /(\d+)\/(\d+)/ from $bp if /(\d+)\/(\d+)/ in $bp",
 ... }
 >>> from dftly import Parser
 >>> parser = Parser()
@@ -153,15 +153,15 @@ precise syntax:
 
 ```python
 >>> ops = r"""
-... sum: # "@col1 + @col2"
+... sum: # "$col1 + $col2"
 ...   add:
 ...     - column: col1
 ...     - column: col2
-... diff: # "@col2 - @col1"
+... diff: # "$col2 - $col1"
 ...   subtract:
 ...     - column: col2
 ...     - column: col1
-... compare: # "@col1 > (@col2 - 3) * 3"
+... compare: # "$col1 > ($col2 - 3) * 3"
 ...   greater_than:
 ...     - column: col1
 ...     - multiply:
@@ -169,16 +169,16 @@ precise syntax:
 ...             - column: col2
 ...             - literal: 3
 ...         - literal: 3
-... str_interp: # 'f"value: {@foo} {@col1}"'
+... str_interp: # 'f"value: {$foo} {$col1}"'
 ...   string_interpolate:
 ...     - literal: "value: {} {}"
 ...     - column: foo
 ...     - column: col1
-... max: # "max(@col1, @col2)"
+... max: # "max($col1, $col2)"
 ...   max:
 ...     - column: col1
 ...     - column: col2
-... conditional: # '"big" if @col1 > 1 else "small"'
+... conditional: # '"big" if $col1 > 1 else "small"'
 ...   conditional:
 ...     when:
 ...       greater_than:
@@ -188,7 +188,7 @@ precise syntax:
 ...       literal: "big"
 ...     otherwise:
 ...       literal: "small"
-... sys_bp: # "extract group 1 of /(\\d+)\\/(\\d+)/ from @bp if /(\\d+)\\/(\\d+)/ in @bp"
+... sys_bp: # "extract group 1 of /(\\d+)\\/(\\d+)/ from $bp if /(\\d+)\\/(\\d+)/ in $bp"
 ...   conditional:
 ...     when:
 ...       regex_match:
@@ -204,7 +204,7 @@ precise syntax:
 ...           literal: (\d+)\/(\d+)
 ...         source:
 ...           column: bp
-... dia_bp: # "extract group 2 of /(\\d+)\\/(\\d+)/ from @bp if /(\\d+)\\/(\\d+)/ in @bp"
+... dia_bp: # "extract group 2 of /(\\d+)\\/(\\d+)/ from $bp if /(\\d+)\\/(\\d+)/ in $bp"
 ...   conditional:
 ...     when:
 ...       regex_match:

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -62,7 +62,7 @@ class StringInterpolate(ArgsOnlyFn):
                 "StringInterpolate requires more than one argument; it takes both the pattern string (first) "
                 "and the fields to interpolate into the pattern (subsequent). "
                 f"Got {len(self.args)} argument(s): {self.args}. "
-                'If you want to infer the fields from the pattern, use a string (e.g., \'f"foo{@bar}" and '
+                'If you want to infer the fields from the pattern, use a string (e.g., \'f"foo{$bar}" and '
                 "the fields will be inferred automatically."
             )
 

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -6,7 +6,7 @@ PLUS: "+"
 MINUS: "-"
 TIMES: "*"
 DIV: "/"
-AT: "@"
+DOLLAR: "$"
 EQ: "=="
 NE: "!="
 GE: ">="
@@ -82,7 +82,7 @@ AGAINST.2: /against/i
 
 ?primary: regex
         | call_expr
-        | (AT)NAME -> column
+        | (DOLLAR)NAME -> column
         | (FORMAT_PFX)STRING -> format_string
         | NUMBER
         | STRING

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -40,9 +40,9 @@ class DftlyGrammar(Transformer):
         >>> DftlyGrammar.parse_str("equal(add(1, multiply(2, 3)), 7)")
         {'equal': [{'add': [1, {'multiply': [2, 3]}]}, 7]}
 
-    You can also express columns using the `"@column_name"` syntax:
+    You can also express columns using the `"$column_name"` syntax:
 
-        >>> DftlyGrammar.parse_str("@a + @b * 3")
+        >>> DftlyGrammar.parse_str("$a + $b * 3")
         {'add': [{'column': 'a'}, {'multiply': [{'column': 'b'}, 3]}]}
 
     Strings will be parsed into string nodes:
@@ -52,23 +52,23 @@ class DftlyGrammar(Transformer):
 
     String interpolation is supported via f-strings:
 
-        >>> DftlyGrammar.parse_str("f'hello {@name}'")
-        {'string_interpolate': [{'literal': 'hello {}'}, '@name']}
+        >>> DftlyGrammar.parse_str("f'hello {$name}'")
+        {'string_interpolate': [{'literal': 'hello {}'}, '$name']}
 
     Conditional expressions can be expressed using the `... if ... else ...` syntax; `else ...` is optional:
 
-        >>> DftlyGrammar.parse_str("'big' if @a > 5")
+        >>> DftlyGrammar.parse_str("'big' if $a > 5")
         {'conditional': {'when': {'greater_than': [{'column': 'a'}, 5]}, 'then': {'literal': 'big'}}}
-        >>> DftlyGrammar.parse_str("'big' if @a > 5 else 'small'")
+        >>> DftlyGrammar.parse_str("'big' if $a > 5 else 'small'")
         {'conditional': {'when': {'greater_than': [{'column': 'a'}, 5]},
                          'then': {'literal': 'big'},
                          'otherwise': {'literal': 'small'}}}
 
     Regex operations are supported via the following syntax:
 
-        >>> DftlyGrammar.parse_str("extract /\\d+/ from @text")
+        >>> DftlyGrammar.parse_str("extract /\\d+/ from $text")
         {'regex_extract': {'pattern': {'literal': '\\\\d+'}, 'source': {'column': 'text'}}}
-        >>> DftlyGrammar.parse_str("/\\d+/ in @text")
+        >>> DftlyGrammar.parse_str("/\\d+/ in $text")
         {'regex_match': {'pattern': {'literal': '\\\\d+'}, 'source': {'column': 'text'}}}
 
     Casting is supported via the `::` or `... as ...` syntax. Note the two have different precedence, with
@@ -115,8 +115,8 @@ class DftlyGrammar(Transformer):
         return str(token)
 
     def column(self, items: list[str]) -> dict:
-        """Resolve the "@column_name" syntax into a column node."""
-        at_sign, column_name = items
+        """Resolve the "$column_name" syntax into a column node."""
+        _, column_name = items
         return Column.from_lark(column_name)
 
     def binary_expr(self, items: list[dict | str]) -> dict:

--- a/tests/test_string_syntax.py
+++ b/tests/test_string_syntax.py
@@ -1,0 +1,29 @@
+import polars as pl
+
+from dftly.parser import Parser
+from dftly.nodes import Add, Column, Literal, StringInterpolate
+
+
+def test_dollar_column_expression_parses_to_nodes():
+    parser = Parser()
+    node = parser("$foo + $bar")
+
+    assert isinstance(node, Add)
+    assert all(isinstance(arg, Column) for arg in node.args)
+
+
+def test_string_interpolation_with_dollar_columns_evaluates():
+    parser = Parser()
+    node = parser('f"hello {$foo} {$bar}"')
+
+    assert isinstance(node, StringInterpolate)
+    pattern, *_ = node.args
+    assert isinstance(pattern, Literal)
+
+    df = pl.DataFrame({"foo": ["Alice", "Bob"], "bar": ["Cooper", "Dylan"]})
+
+    result = df.select(node.polars_expr.alias("greeting"))
+    assert result.to_dicts() == [
+        {"greeting": "hello Alice Cooper"},
+        {"greeting": "hello Bob Dylan"},
+    ]


### PR DESCRIPTION
## Summary
- update the string grammar to parse column references that use a `$` prefix
- refresh parser documentation, error messaging, and README examples to show the new column syntax
- add parser tests covering dollar-prefixed column expressions and interpolation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ead25a6af8832c80ff2e9ca009bebb