### PR TITLE
Add coalesce() function for null-fallback expressions

### DIFF
--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -12,6 +12,7 @@ from .arithmetic import (
     Mean,
     Min,
     Max,
+    Coalesce,
 )
 from .comparison import (
     GreaterThan,
@@ -37,6 +38,7 @@ __nodes = [
     Mean,
     Min,
     Max,
+    Coalesce,
     Add,
     Subtract,
     Multiply,

--- a/src/dftly/nodes/arithmetic.py
+++ b/src/dftly/nodes/arithmetic.py
@@ -217,3 +217,18 @@ class Max(ArgsOnlyFn):
 
     KEY = "max"
     pl_fn = pl.max_horizontal
+
+
+class Coalesce(ArgsOnlyFn):
+    """This non-terminal node returns the first non-null value among its arguments.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(Coalesce(Literal(None), Literal(1), Literal(2)).polars_expr).item()
+        1
+        >>> pl.select(Coalesce(Literal(3), Literal(None)).polars_expr).item()
+        3
+    """
+
+    KEY = "coalesce"
+    pl_fn = pl.coalesce


### PR DESCRIPTION
## Summary
- Adds a `Coalesce` node that returns the first non-null value from its arguments
- Maps directly to `pl.coalesce()`, following the same `ArgsOnlyFn` pattern as `min()`, `max()`, `mean()`
- Grammar support comes automatically via the node registration system

## Test plan
- [x] All existing doctests pass
- [x] New doctests cover null-fallback behavior

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)