### PR TITLE
Add is_expression() utility for detecting compound expressions

### DIFF
--- a/src/dftly/__init__.py
+++ b/src/dftly/__init__.py
@@ -1,2 +1,3 @@
 from .parser import Parser as Parser
 from .parser import extract_columns as extract_columns
+from .parser import is_expression as is_expression

--- a/src/dftly/parser.py
+++ b/src/dftly/parser.py
@@ -1,4 +1,4 @@
-from .nodes.base import NodeBase
+from .nodes.base import Column, Literal, NodeBase
 from pathlib import Path
 import re
 import warnings
@@ -41,6 +41,43 @@ def extract_columns(expr: str) -> set[str]:
         ['col1', 'col2']
     """
     return set(_COLUMN_RE.findall(expr))
+
+
+def is_expression(
+    value: str, input_schema: dict[str, str | None] | None = None
+) -> bool:
+    """Check whether a string is a compound dftly expression (not a plain literal or column).
+
+    Returns ``True`` when *value* parses successfully as something other than a bare
+    :class:`~dftly.nodes.base.Literal` or :class:`~dftly.nodes.base.Column`.  Returns
+    ``False`` for plain literals, bare column references, and strings that fail to parse.
+
+    Args:
+        value: The string to check.
+        input_schema: Accepted for forward-compatible API use but currently unused.
+
+    Returns:
+        ``True`` if the value is a compound expression, ``False`` otherwise.
+
+    Examples:
+        >>> is_expression("timestamp")
+        False
+        >>> is_expression("ADMISSION")
+        False
+        >>> is_expression("col1 + col2")
+        True
+        >>> is_expression("hash(mrn)")
+        True
+        >>> is_expression("broken >< syntax")
+        False
+    """
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            node = Parser()(value)
+    except ValueError:
+        return False
+    return not isinstance(node, (Literal, Column))
 
 
 class Parser:


### PR DESCRIPTION
## Summary
- Adds `is_expression(value, input_schema=None)` to detect whether a string is a dftly expression vs a plain value
- Returns `True` for compound expressions (operators, functions, casts), `False` for simple column names, literals, and unparseable input
- Exported from the top-level `dftly` package

## Test plan
- [x] All existing doctests pass
- [x] New doctests cover all behavior examples from #41

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)