### PR TITLE
Add strict parameter to Strptime for conditional compatibility

### DIFF
--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -306,10 +306,21 @@ class Strptime(KwargsOnlyFn):
 
         >>> pl.select(Strptime(format=Literal("%Y %H:%M"), source=Literal("2023 12:11")).polars_expr).item()
         datetime.datetime(2023, 1, 1, 12, 11)
+
+    Non-strict parsing produces null instead of raising on format mismatch:
+
+        >>> non_strict = Strptime(
+        ...     format=Literal("%Y-%m-%d %H:%M:%S"),
+        ...     source=Literal("2020-06-20"),
+        ...     strict=Literal(False),
+        ... )
+        >>> print(pl.select(non_strict.polars_expr).item())
+        None
     """
 
     KEY = "strptime"
     REQUIRED_KWARGS = {"format", "source"}
+    OPTIONAL_KWARGS = {"strict"}
 
     # See https://docs.rs/chrono/latest/chrono/format/strftime/index.html
     DATE_PARTS: ClassVar[set[str]] = {
@@ -417,11 +428,31 @@ class Strptime(KwargsOnlyFn):
             )
 
     @property
+    def strict(self) -> bool:
+        strict_node = self.kwargs.get("strict", None)
+        if strict_node is None:
+            return True  # default: strict=True for backwards compatibility
+        if not isinstance(strict_node, NodeBase):
+            raise ValueError(
+                "The strict argument must be a NodeBase instance that evaluates to a boolean."
+            )
+        try:
+            val = pl.select(strict_node.polars_expr).item()
+        except Exception as e:
+            raise ValueError("The strict argument must evaluate to a boolean.") from e
+        if not isinstance(val, bool):
+            raise ValueError(f"The strict argument must be a boolean, got {type(val)}")
+        return val
+
+    @property
     def polars_expr(self) -> pl.Expr:
         source_expr = self.kwargs["source"].polars_expr
+        strict = self.strict
 
         return source_expr.str.strptime(
-            dtype=DATE_TIME_TYPES[self.output_type], format=self.format_str
+            dtype=DATE_TIME_TYPES[self.output_type],
+            format=self.format_str,
+            strict=strict,
         )
 
     @classmethod

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -49,6 +49,7 @@ CAST: "::"
 AND_SYM: "&&"
 OR_SYM: "||"
 NOT_SYM: "!"
+QUESTION: "?"
 
 // Keywords — priority .2 ensures these are preferred over NAME
 FORMAT_PFX: "f"
@@ -76,6 +77,7 @@ FROM.2: /from/i
 // Lowest precedence: global cast with `as`/`@` binds last
 ?global_cast: conditional AS NAME   -> cast_expr
             | conditional AS STRING -> strptime
+            | conditional AS QUESTION STRING -> strptime_nonstrict
             | conditional AT TIME   -> binary_expr
             | conditional
 
@@ -100,6 +102,7 @@ FROM.2: /from/i
 // Higher precedence: local cast with `::` binds tighter than arithmetic
 ?local_cast: unary CAST NAME   -> cast_expr
            | unary CAST STRING -> strptime
+           | unary CAST QUESTION STRING -> strptime_nonstrict
            | unary
 
 ?unary: (NOT_SYM|NOT) unary   -> unary_expr

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -264,7 +264,7 @@ class DftlyGrammar(Transformer):
             "strptime": {
                 "format": format_str,
                 "source": source,
-                "strict": {"literal": False},
+                "strict": Literal.from_lark(False),
             }
         }
 

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -215,9 +215,8 @@ class DftlyGrammar(Transformer):
     def _discard_token(self, _: Token) -> Discard:
         return Discard
 
-    IF = ELSE = EXTRACT = GROUP = OF = FROM = IN = CAST = AS = FORMAT_PFX = DOLLAR = (
-        QUESTION
-    ) = _discard_token
+    IF = ELSE = EXTRACT = GROUP = OF = FROM = IN = CAST = AS = _discard_token
+    FORMAT_PFX = DOLLAR = QUESTION = _discard_token
 
     def NAME(self, val: Token) -> str:
         return str(val)
@@ -260,12 +259,14 @@ class DftlyGrammar(Transformer):
         return {"bare_word": items[0]}
 
     def strptime_nonstrict(self, items: list[Any]) -> dict:
-        from ..nodes.str import Strptime
-
         source, format_str = items
-        result = Strptime.from_lark([source, format_str])
-        result[Strptime.KEY]["strict"] = Literal.from_lark(False)
-        return result
+        return {
+            "strptime": {
+                "format": format_str,
+                "source": source,
+                "strict": Literal.from_lark(False),
+            }
+        }
 
     def cast_expr(self, items: list[Any]) -> dict:
         input, output_type = items

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -264,7 +264,7 @@ class DftlyGrammar(Transformer):
             "strptime": {
                 "format": format_str,
                 "source": source,
-                "strict": Literal.from_lark(False),
+                "strict": {"literal": False},
             }
         }
 

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -259,14 +259,11 @@ class DftlyGrammar(Transformer):
         return {"bare_word": items[0]}
 
     def strptime_nonstrict(self, items: list[Any]) -> dict:
-        source, format_str = items
-        return {
-            "strptime": {
-                "format": format_str,
-                "source": source,
-                "strict": Literal.from_lark(False),
-            }
-        }
+        from ..nodes.str import Strptime
+
+        result = Strptime.from_lark(items)
+        result[Strptime.KEY]["strict"] = Literal.from_lark(False)
+        return result
 
     def cast_expr(self, items: list[Any]) -> dict:
         input, output_type = items

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -143,6 +143,17 @@ class DftlyGrammar(Transformer):
         >>> DftlyGrammar.parse_str("'2023 01 01'::'%Y %m %d'")
         {'strptime': {'format': {'literal': '%Y %m %d'},
                       'source': {'literal': '2023 01 01'}}}
+
+    Non-strict strptime uses the ``?`` prefix on the format string:
+
+        >>> DftlyGrammar.parse_str('$dod::?"%Y-%m-%d %H:%M:%S"')
+        {'strptime': {'format': {'literal': '%Y-%m-%d %H:%M:%S'},
+                      'source': {'column': 'dod'},
+                      'strict': {'literal': False}}}
+        >>> DftlyGrammar.parse_str('$dod as ?"%Y-%m-%d %H:%M:%S"')
+        {'strptime': {'format': {'literal': '%Y-%m-%d %H:%M:%S'},
+                      'source': {'column': 'dod'},
+                      'strict': {'literal': False}}}
     """
 
     @classmethod
@@ -205,8 +216,8 @@ class DftlyGrammar(Transformer):
         return Discard
 
     IF = ELSE = EXTRACT = GROUP = OF = FROM = IN = CAST = AS = FORMAT_PFX = DOLLAR = (
-        _discard_token
-    )
+        QUESTION
+    ) = _discard_token
 
     def NAME(self, val: Token) -> str:
         return str(val)
@@ -247,6 +258,14 @@ class DftlyGrammar(Transformer):
 
     def bare_word(self, items: list[Any]) -> dict:
         return {"bare_word": items[0]}
+
+    def strptime_nonstrict(self, items: list[Any]) -> dict:
+        from ..nodes.str import Strptime
+
+        source, format_str = items
+        result = Strptime.from_lark([source, format_str])
+        result[Strptime.KEY]["strict"] = Literal.from_lark(False)
+        return result
 
     def cast_expr(self, items: list[Any]) -> dict:
         input, output_type = items


### PR DESCRIPTION
## Summary
- Adds optional `strict` kwarg to `Strptime` node (defaults to `True` for backwards compat)
- Adds `::?"fmt"` and `as ?"fmt"` syntax for non-strict parsing in string expressions
- Non-strict mode produces `null` instead of raising on format mismatches, enabling use inside `when/then/otherwise` conditionals

## Test plan
- [x] All existing doctests pass
- [x] New doctests for non-strict parsing returning null
- [x] New doctests for `::?` and `as ?` grammar syntax

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)