### PR TITLE
Support fallback date format parsing with multiple formats

### DIFF
--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -12,6 +12,7 @@ from .arithmetic import (
     Mean,
     Min,
     Max,
+    Coalesce,
 )
 from .comparison import (
     GreaterThan,
@@ -54,6 +55,7 @@ __nodes = [
     Cast,
     Strptime,
     SetTime,
+    Coalesce,
 ]
 
 NODES = NodeBase.unique_dict_by_prop(__nodes)

--- a/src/dftly/nodes/arithmetic.py
+++ b/src/dftly/nodes/arithmetic.py
@@ -217,3 +217,18 @@ class Max(ArgsOnlyFn):
 
     KEY = "max"
     pl_fn = pl.max_horizontal
+
+
+class Coalesce(ArgsOnlyFn):
+    """This non-terminal node returns the first non-null value from its arguments.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(Coalesce(Literal(None), Literal(1), Literal(2)).polars_expr).item()
+        1
+        >>> pl.select(Coalesce(Literal(3), Literal(None)).polars_expr).item()
+        3
+    """
+
+    KEY = "coalesce"
+    pl_fn = pl.coalesce

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -456,19 +456,6 @@ class Strptime(KwargsOnlyFn):
 
     @classmethod
     def from_lark(cls, items: list[Any]) -> dict[str, Any]:
-        if len(items) == 2:
-            source, format = items
-            return {cls.KEY: {"format": format, "source": source}}
+        source, format = items
 
-        # Multiple formats: produce a coalesce of non-strict strptime calls
-        source = items[0]
-        formats = items[1:]
-        from .base import Literal
-
-        false_lit = Literal.from_lark(False)
-        strptime_nodes = []
-        for fmt in formats:
-            strptime_nodes.append(
-                {cls.KEY: {"format": fmt, "source": source, "strict": false_lit}}
-            )
-        return {"coalesce": strptime_nodes}
+        return {cls.KEY: {"format": format, "source": source}}

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -306,10 +306,21 @@ class Strptime(KwargsOnlyFn):
 
         >>> pl.select(Strptime(format=Literal("%Y %H:%M"), source=Literal("2023 12:11")).polars_expr).item()
         datetime.datetime(2023, 1, 1, 12, 11)
+
+    Non-strict parsing produces null instead of raising on format mismatch:
+
+        >>> non_strict = Strptime(
+        ...     format=Literal("%Y-%m-%d %H:%M:%S"),
+        ...     source=Literal("2020-06-20"),
+        ...     strict=Literal(False),
+        ... )
+        >>> print(pl.select(non_strict.polars_expr).item())
+        None
     """
 
     KEY = "strptime"
     REQUIRED_KWARGS = {"format", "source"}
+    OPTIONAL_KWARGS = {"strict"}
 
     # See https://docs.rs/chrono/latest/chrono/format/strftime/index.html
     DATE_PARTS: ClassVar[set[str]] = {
@@ -379,6 +390,23 @@ class Strptime(KwargsOnlyFn):
             )
 
     @property
+    def strict(self) -> bool:
+        strict_node = self.kwargs.get("strict", None)
+        if strict_node is None:
+            return True
+        if not isinstance(strict_node, NodeBase):
+            raise ValueError(
+                "The strict argument must be a NodeBase instance that evaluates to a boolean."
+            )
+        try:
+            val = pl.select(strict_node.polars_expr).item()
+        except Exception as e:
+            raise ValueError("The strict argument must evaluate to a boolean.") from e
+        if not isinstance(val, bool):
+            raise ValueError(f"The strict argument must be a boolean, got {type(val)}")
+        return val
+
+    @property
     def format_str(self) -> str:
         fmt = self.kwargs["format"]
 
@@ -421,11 +449,26 @@ class Strptime(KwargsOnlyFn):
         source_expr = self.kwargs["source"].polars_expr
 
         return source_expr.str.strptime(
-            dtype=DATE_TIME_TYPES[self.output_type], format=self.format_str
+            dtype=DATE_TIME_TYPES[self.output_type],
+            format=self.format_str,
+            strict=self.strict,
         )
 
     @classmethod
     def from_lark(cls, items: list[Any]) -> dict[str, Any]:
-        source, format = items
+        if len(items) == 2:
+            source, format = items
+            return {cls.KEY: {"format": format, "source": source}}
 
-        return {cls.KEY: {"format": format, "source": source}}
+        # Multiple formats: produce a coalesce of non-strict strptime calls
+        source = items[0]
+        formats = items[1:]
+        from .base import Literal
+
+        false_lit = Literal.from_lark(False)
+        strptime_nodes = []
+        for fmt in formats:
+            strptime_nodes.append(
+                {cls.KEY: {"format": fmt, "source": source, "strict": false_lit}}
+            )
+        return {"coalesce": strptime_nodes}

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -49,6 +49,7 @@ CAST: "::"
 AND_SYM: "&&"
 OR_SYM: "||"
 NOT_SYM: "!"
+QUESTION: "?"
 
 // Keywords — priority .2 ensures these are preferred over NAME
 FORMAT_PFX: "f"
@@ -75,7 +76,8 @@ FROM.2: /from/i
 
 // Lowest precedence: global cast with `as`/`@` binds last
 ?global_cast: conditional AS NAME   -> cast_expr
-            | conditional AS STRING -> strptime
+            | conditional AS STRING ("," STRING)* -> strptime
+            | conditional AS QUESTION STRING -> strptime_nonstrict
             | conditional AT TIME   -> binary_expr
             | conditional
 
@@ -99,7 +101,8 @@ FROM.2: /from/i
 
 // Higher precedence: local cast with `::` binds tighter than arithmetic
 ?local_cast: unary CAST NAME   -> cast_expr
-           | unary CAST STRING -> strptime
+           | unary CAST STRING ("," STRING)* -> strptime
+           | unary CAST QUESTION STRING -> strptime_nonstrict
            | unary
 
 ?unary: (NOT_SYM|NOT) unary   -> unary_expr

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -76,7 +76,7 @@ FROM.2: /from/i
 
 // Lowest precedence: global cast with `as`/`@` binds last
 ?global_cast: conditional AS NAME   -> cast_expr
-            | conditional AS STRING ("," STRING)* -> strptime
+            | conditional AS STRING -> strptime
             | conditional AS QUESTION STRING -> strptime_nonstrict
             | conditional AT TIME   -> binary_expr
             | conditional
@@ -101,7 +101,7 @@ FROM.2: /from/i
 
 // Higher precedence: local cast with `::` binds tighter than arithmetic
 ?local_cast: unary CAST NAME   -> cast_expr
-           | unary CAST STRING ("," STRING)* -> strptime
+           | unary CAST STRING -> strptime
            | unary CAST QUESTION STRING -> strptime_nonstrict
            | unary
 

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -143,6 +143,16 @@ class DftlyGrammar(Transformer):
         >>> DftlyGrammar.parse_str("'2023 01 01'::'%Y %m %d'")
         {'strptime': {'format': {'literal': '%Y %m %d'},
                       'source': {'literal': '2023 01 01'}}}
+
+    Non-strict strptime uses the ``?`` prefix on the format string:
+
+        >>> DftlyGrammar.parse_str('$dod::?"%Y-%m-%d %H:%M:%S"')
+        {'strptime': {'format': {'literal': '%Y-%m-%d %H:%M:%S'}, 'source': {'column': 'dod'}, 'strict': {'literal': False}}}
+
+    Fallback format parsing tries multiple formats in sequence:
+
+        >>> DftlyGrammar.parse_str('$dod::"%Y-%m-%d %H:%M:%S", "%Y-%m-%d"')
+        {'coalesce': [{'strptime': {'format': {'literal': '%Y-%m-%d %H:%M:%S'}, 'source': {'column': 'dod'}, 'strict': {'literal': False}}}, {'strptime': {'format': {'literal': '%Y-%m-%d'}, 'source': {'column': 'dod'}, 'strict': {'literal': False}}}]}
     """
 
     @classmethod
@@ -205,8 +215,8 @@ class DftlyGrammar(Transformer):
         return Discard
 
     IF = ELSE = EXTRACT = GROUP = OF = FROM = IN = CAST = AS = FORMAT_PFX = DOLLAR = (
-        _discard_token
-    )
+        QUESTION
+    ) = _discard_token
 
     def NAME(self, val: Token) -> str:
         return str(val)
@@ -251,3 +261,13 @@ class DftlyGrammar(Transformer):
     def cast_expr(self, items: list[Any]) -> dict:
         input, output_type = items
         return Cast.from_lark([input, Literal.from_lark(output_type)])
+
+    def strptime_nonstrict(self, items: list[Any]) -> dict:
+        source, format_str = items
+        return {
+            "strptime": {
+                "format": format_str,
+                "source": source,
+                "strict": Literal.from_lark(False),
+            }
+        }

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -149,9 +149,10 @@ class DftlyGrammar(Transformer):
         >>> DftlyGrammar.parse_str('$dod::?"%Y-%m-%d %H:%M:%S"')
         {'strptime': {'format': {'literal': '%Y-%m-%d %H:%M:%S'}, 'source': {'column': 'dod'}, 'strict': {'literal': False}}}
 
-    Fallback format parsing tries multiple formats in sequence:
+    For fallback format parsing (trying multiple formats), compose ``coalesce()`` with non-strict
+    strptime — each building block reduces cleanly to its base form:
 
-        >>> DftlyGrammar.parse_str('$dod::"%Y-%m-%d %H:%M:%S", "%Y-%m-%d"')
+        >>> DftlyGrammar.parse_str('coalesce($dod::?"%Y-%m-%d %H:%M:%S", $dod::?"%Y-%m-%d")')
         {'coalesce': [{'strptime': {'format': {'literal': '%Y-%m-%d %H:%M:%S'}, 'source': {'column': 'dod'}, 'strict': {'literal': False}}}, {'strptime': {'format': {'literal': '%Y-%m-%d'}, 'source': {'column': 'dod'}, 'strict': {'literal': False}}}]}
     """
 


### PR DESCRIPTION
## Summary
- Adds Coalesce node for null-fallback expressions (same as #48)
- Adds strict parameter to Strptime with `::?"%fmt"` syntax (same as #50)
- Documents the compositional approach for fallback format parsing

## Fallback format parsing
Instead of special grammar syntax, users compose `coalesce()` with non-strict strptime:

```yaml
time: 'coalesce($dod::?"%Y-%m-%d %H:%M:%S", $dod::?"%Y-%m-%d")'
```

Each layer reduces cleanly to its base form and works in both string and dict/YAML form.

## Design note
An earlier version added comma-separated format syntax but this was removed because `from_lark` produced a `coalesce` node from a `strptime` grammar rule, violating the principle that every string form must reduce to the base form of the node it represents.

## Test plan
- [x] All 50 tests pass
- [x] Doctests for coalesce, non-strict strptime, and compositional fallback parsing

Closes #46. Related: #47, #45