### PR TITLE
Document design principles and fix outdated docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,147 +1,248 @@
-# WARP.md
+# AGENTS.md
 
-This file provides guidance to WARP (warp.dev) when working with code in this repository.
+Guidance for AI coding agents (Claude Code, Cursor, Copilot, Warp AI, etc.) working on this
+repository.
 
 ## Overview
 
-dftly (pronounced "deftly") is a DataFrame Transformation Language parser that provides a YAML-friendly DSL for expressing simple dataframe operations. The library parses YAML configurations into a fully-resolved intermediate representation that can be translated to different execution engines (currently supports Polars).
+dftly (pronounced "deftly") is a DataFrame Transformation Language parser that provides a
+YAML-friendly DSL for expressing simple dataframe operations. The library parses expressions into
+an AST (abstract syntax tree) of node objects, each of which can produce a Polars expression.
 
-## Development Commands
+## Core Design Principle: The Form Hierarchy
 
-### Installation & Setup
+**This is the most important thing to understand about dftly's architecture.**
 
-```bash
-# Development installation with all dependencies
-pip install -e ".[dev,tests,polars]"
+Every expression in dftly can be represented in three equivalent forms, each of which is a
+different notation for the same underlying tree:
 
-# Enable pre-commit hooks
-pre-commit install
+1. **Base form (dict/YAML)** -- The fully explicit tree representation. Every node type, every
+    argument, every keyword argument is spelled out. This is the canonical, unambiguous form.
+
+    ```yaml
+    add:
+      - column: col1
+      - multiply:
+          - column: col2
+          - literal: 3
+    ```
+
+2. **Class form** -- Python objects. Isomorphic to the base form. Every dict key maps to a node
+    class, every value maps to constructor arguments.
+
+    ```python
+    Add(Column("col1"), Multiply(Column("col2"), Literal(3)))
+    ```
+
+3. **String form** -- Human-readable syntax parsed by the Lark grammar. Syntactic sugar over the
+    base form.
+
+    ```
+    $col1 + $col2 * 3
+    ```
+
+### The Rule
+
+**All forms must reduce to the same base-form tree.** This means:
+
+- **Start from the base form.** When adding a new feature, first define what the base-form dict
+    looks like. What node class does it correspond to? What are its required/optional kwargs or
+    positional args? Only then consider whether string-form sugar is warranted.
+
+- **String form is sugar, not structure.** The grammar and `from_lark` methods must produce dicts
+    that the Parser can resolve into the same node objects you would get from the dict form.
+    `from_lark` must return a dict keyed by its own node's `KEY` -- never a different node type.
+
+- **No magic in the grammar layer.** If `from_lark` for node X returns `{"Y": ...}` (a different
+    node type), that is a design violation. The grammar can provide convenient syntax, but the
+    output must be a dict that maps to the node the grammar rule is named after.
+
+- **Every string-form feature must have a dict-form equivalent.** If users can write it in a
+    string expression, they must also be able to write the equivalent dict/YAML. If you can't
+    define a clean base form for a feature, don't add string syntax for it. Composing existing
+    primitives is always preferable to grammar-level magic.
+
+### Example of a violation (and the fix)
+
+Bad -- `Strptime.from_lark` returning a `coalesce` node for multi-format syntax:
+
+```python
+# WRONG: grammar rule is "strptime" but output is "coalesce"
+def from_lark(cls, items):
+    if len(items) > 2:
+        return {"coalesce": [{"strptime": ...}, {"strptime": ...}]}
 ```
 
-### Testing
+Good -- users compose existing primitives:
 
-```bash
-# Run all tests
-pytest
-
-# Run tests with coverage
-pytest --cov=dftly
-
-# Run specific test files
-pytest tests/test_parser.py
-pytest tests/test_polars_engine.py
-pytest tests/test_integration_polars.py
-
-# Run doctests in README
-pytest --doctest-glob=README.md
+```
+coalesce($dod::?"%Y-%m-%d %H:%M:%S", $dod::?"%Y-%m-%d")
 ```
 
-### Code Quality
-
-```bash
-# Run all pre-commit hooks
-pre-commit run --all-files
-```
+Each piece (`coalesce`, non-strict `strptime`) has its own base form and the composition is
+explicit.
 
 ## Architecture
 
-### Core Components
+### Project Structure
 
-1. **Parser (`src/dftly/parser.py`)**
+```
+src/dftly/
+  __init__.py          -- Public API: Parser, extract_columns
+  parser.py            -- Parser class (dict/YAML/string -> Node objects)
+  nodes/
+    __init__.py         -- Node registration (NODES dict, BINARY_OPS, UNARY_OPS)
+    base.py             -- NodeBase, Terminal, Nonterminal, Literal, Column
+    arithmetic.py       -- Add, Subtract, Multiply, Divide, Mean, Min, Max, Hash, etc.
+    comparison.py       -- GreaterThan, LessThan, Equal, NotEqual, etc.
+    conditional.py      -- Conditional (if/then/else)
+    str.py              -- StringInterpolate, RegexExtract, RegexMatch, Strptime
+    datetime.py         -- SetTime
+    types.py            -- Cast
+    utils.py            -- Validation helpers
+  str_form/
+    grammar.lark        -- LALR(1) grammar for string expressions
+    parser.py           -- DftlyGrammar (Lark Transformer: tokens -> base-form dicts)
+```
 
-    - Main entry point via `from_yaml()` function
-    - Handles string parsing using Lark grammar
-    - Transforms simplified YAML syntax to fully-resolved AST nodes
+### Parsing Pipeline
 
-2. **AST Nodes (`src/dftly/nodes.py`)**
+```
+String expression          Dict/YAML input
+       |                         |
+  [Lark grammar]                 |
+       |                         |
+  [DftlyGrammar]                 |
+  (tokens -> dicts)              |
+       |                         |
+       +---- base-form dict -----+
+                    |
+              [Parser.__call__]
+              (dict -> Node objects)
+                    |
+              Node tree (class form)
+                    |
+              .polars_expr property
+                    |
+              pl.Expr (Polars expression)
+```
 
-    - `Literal`: Simple values (numbers, strings, booleans)
-    - `Column`: References to dataframe columns with optional type info
-    - `Expression`: Complex operations with type and arguments
+### Node Class Hierarchy
 
-3. **Grammar (`src/dftly/grammar.lark`)**
+- `NodeBase` (abstract) -- base for all nodes
+    - `Terminal` -- nodes whose args are raw values, not other nodes
+        - `Literal` -- POD values (int, float, str, bool, None, datetime)
+        - `Column` -- column references (`$col_name`)
+    - `Nonterminal` -- nodes whose args must be other `NodeBase` instances
+        - `ArgsOnlyFn` -- variadic positional args (Add, Min, Max, Mean, Coalesce, Hash)
+        - `KwargsOnlyFn` -- keyword args only (Conditional, Strptime, RegexExtract, RegexMatch)
+        - `BinaryOp` -- exactly 2 positional args (Subtract, Divide, comparisons, SetTime)
+        - `UnaryOp` -- exactly 1 positional arg (Not, Negate)
 
-    - Lark-based parser grammar for string expressions
-    - Supports operator precedence, function calls, and complex expressions
-    - Handles mathematical, boolean, and string operations
+### Node Registration
 
-4. **Execution Engine (`src/dftly/polars.py`)**
+Nodes are registered in `nodes/__init__.py`:
 
-    - Translates AST nodes to Polars expressions
-    - Maps dftly operations to corresponding Polars operations
-    - Handles type conversions and complex operations
+1. Add the class to the imports
+2. Add it to the `__nodes` list
+3. `NODES = NodeBase.unique_dict_by_prop(__nodes)` creates the `{KEY: class}` mapping
 
-### Two-Stage Parsing Process
+Once registered, the node automatically gets:
 
-1. **Simplified Form → Fully Resolved Form**
+- Dict-form parsing via `Parser.__call__` (matches on KEY)
+- Function-call syntax in the grammar via `DftlyGrammar.func()` (e.g., `min($a, $b)`)
 
-    - YAML/dictionary input is parsed into unambiguous AST nodes
-    - String expressions are parsed using the Lark grammar
-    - Context-aware parsing based on input schema
+Infix operators additionally need:
 
-2. **Fully Resolved Form → Execution Engine**
+- A `SYM` class variable on the node
+- Addition to `BINARY_OPS` or `UNARY_OPS` in `__init__.py`
+- A grammar rule in `grammar.lark` at the appropriate precedence level
 
-    - AST nodes are translated to execution-specific expressions
-    - Currently supports Polars via `to_polars()` function
-    - Extensible design for additional engines
+## Adding a New Node Type
 
-### Expression Types Supported
+Follow this checklist:
 
-The library supports a comprehensive set of operations:
+1. **Define the base form.** What does the dict look like? Example:
 
-- Arithmetic: `ADD`, `SUBTRACT`
-- Boolean: `AND`, `OR`, `NOT`
-- Conditional: `CONDITIONAL` (ternary if-else)
-- Type operations: `TYPE_CAST`, `COALESCE`
-- String operations: `STRING_INTERPOLATE`, `REGEX`
-- Temporal: `RESOLVE_TIMESTAMP`, `PARSE_WITH_FORMAT_STRING`
-- Membership: `VALUE_IN_LITERAL_SET`, `VALUE_IN_RANGE`
-- Utility: `HASH_TO_INT`
+    ```yaml
+    my_node:
+      - column: a
+      - literal: 42
+    ```
 
-### Key Design Principles
+2. **Create the class** in the appropriate `nodes/*.py` file:
 
-1. **Human-Readable Input**: YAML-friendly syntax for non-technical users
-2. **Fully-Resolved Intermediate Form**: Unambiguous representation for reliable execution
-3. **Engine Independence**: Core parsing separate from execution engines
-4. **Limited Scope**: Focuses on row-wise transformations, not table-level operations
+    - Set `KEY = "my_node"`
+    - Choose the right base class (`ArgsOnlyFn`, `KwargsOnlyFn`, `BinaryOp`, `UnaryOp`)
+    - Implement `polars_expr` property
+    - Implement `from_lark` class method (must return `{cls.KEY: ...}`)
+    - Add doctests
+
+3. **Register** in `nodes/__init__.py` (import + add to `__nodes`)
+
+4. **String syntax** (optional):
+
+    - If function-call syntax suffices (`my_node($a, $b)`), nothing else needed
+    - If infix syntax is desired, add `SYM`, update `BINARY_OPS`/`UNARY_OPS`, add grammar rule
+
+5. **Run tests**: `uv run pytest --tb=short`
+
+## Development Commands
+
+```bash
+# Install with dev dependencies
+uv sync
+
+# Run all tests (doctests in source + README)
+uv run pytest
+
+# Run tests with coverage
+uv run pytest --cov=dftly
+
+# Run pre-commit hooks
+pre-commit run --all-files
+```
 
 ## Testing Strategy
 
-- **Unit Tests**: Individual parser components and node types
-- **Integration Tests**: End-to-end parsing and execution with Polars
-- **Doctest**: Examples in README.md are automatically tested
-- **Type Safety**: All code uses type hints and is validated
+- **Doctests are the primary test mechanism.** Every node class and public function should have
+    doctests demonstrating usage and edge cases.
+- **README.md is tested** via `--doctest-glob=README.md` -- examples must be runnable.
+- **conftest.py** provides the doctest namespace (`pl`, `datetime`, `Path`, etc.).
+- Prefer doctests over separate test files unless the test is too complex for a docstring.
+
+## Key Conventions
+
+- All node `KEY` values are lowercase strings.
+- Column references use `$` prefix in string form (`$col_name`).
+- `from_lark` must return `{cls.KEY: args_or_kwargs}` -- never a different node's key.
+- `polars_expr` is a property, not a method.
+- `pl_fn` is a `ClassVar` on `ArgsOnlyFn` subclasses -- don't use `@classmethod` for it.
+- Keyword-only nodes validate via `REQUIRED_KWARGS` and `OPTIONAL_KWARGS` sets.
+- Custom transformer methods in `DftlyGrammar` (like `cast_expr`, `strptime_nonstrict`) are
+    acceptable when the grammar needs to wrap tokens into the base form, but they must still
+    produce dicts keyed by the correct node KEY.
+
+## Common Pitfalls
+
+- **Don't add string syntax without a base form.** If there's no clean dict representation,
+    the feature shouldn't exist as syntax sugar.
+- **Don't have `from_lark` return a different node type.** This breaks the form hierarchy.
+- **Don't evaluate polars expressions in string-form parsing.** The grammar transformer
+    (`DftlyGrammar`) should only produce dicts. Polars evaluation happens later via
+    `polars_expr`.
+- **Don't modify the grammar without considering precedence.** The LALR(1) grammar has
+    carefully ordered precedence levels. Adding rules at the wrong level causes ambiguities.
 
 ## Important Files
 
-- `src/dftly/__init__.py`: Public API exports
-- `src/dftly/parser.py`: Core parsing logic with `DftlyTransformer` class
-- `src/dftly/nodes.py`: AST node definitions with validation
-- `src/dftly/grammar.lark`: Lark grammar for string expression parsing
-- `src/dftly/polars.py`: Polars execution engine implementation
-- `pyproject.toml`: Project configuration with dependencies and build settings
-- `.pre-commit-config.yaml`: Code quality automation
-
-## Common Development Patterns
-
-### Adding New Expression Types
-
-1. Add expression name to `_EXPR_TYPES` set in `parser.py`
-2. Implement parsing logic in `Parser._parse_mapping()`
-3. Add execution logic in `polars.py` `_expr_to_polars()`
-4. Add comprehensive tests covering parsing and execution
-5. Update documentation and examples
-
-### Extending Grammar
-
-1. Modify `grammar.lark` with new syntax rules
-2. Update `DftlyTransformer` class in `parser.py`
-3. Add corresponding expression type handling
-4. Test string parsing alongside dictionary forms
-
-### Adding New Execution Engines
-
-1. Create new module (e.g., `src/dftly/pandas.py`)
-2. Implement `to_[engine]()` function similar to `to_polars()`
-3. Map each expression type to engine-specific operations
-4. Add comprehensive integration tests
+| File                              | Purpose                                                |
+| --------------------------------- | ------------------------------------------------------ |
+| `src/dftly/__init__.py`           | Public API exports                                     |
+| `src/dftly/parser.py`             | Parser class, `extract_columns`, `is_expression`       |
+| `src/dftly/nodes/base.py`         | NodeBase hierarchy and terminal nodes                  |
+| `src/dftly/nodes/__init__.py`     | Node registration (`NODES`, `BINARY_OPS`, `UNARY_OPS`) |
+| `src/dftly/str_form/grammar.lark` | LALR(1) expression grammar                             |
+| `src/dftly/str_form/parser.py`    | `DftlyGrammar` Lark transformer                        |
+| `conftest.py`                     | Doctest namespace fixtures                             |
+| `pyproject.toml`                  | Project config, test settings, dependencies            |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Pull requests (PRs) are warmly welcomed! New contributions should generally buil
 1. **Fork and Clone the Repository**: Start by forking the relevant repository and cloning your fork locally.
 
     ```sh
-    git clone https://github.com/your-username/MEDS_extract.git
+    git clone https://github.com/your-username/dftly.git
     ```
 
 2. **Create a Branch**: For each contribution, create a dedicated branch with a descriptive name based on the `dev` branch:
@@ -45,7 +45,7 @@ Pull requests (PRs) are warmly welcomed! New contributions should generally buil
 
 4. **Testing and Code Style**:
 
-    - MEDS uses automated workflows for testing and pre-commit code style checks. PRs must pass these checks to be accepted.
+    - dftly uses automated workflows for testing and pre-commit code style checks. PRs must pass these checks to be accepted.
     - You can install the necessary development dependencies locally with:
         ```sh
         pip install -e .[dev]

--- a/README.md
+++ b/README.md
@@ -188,6 +188,40 @@ Bare word 'TYPO' interpreted as string literal in a subexpression. Did you mean 
 
 ```
 
+## Design Philosophy
+
+Dftly expressions can be written in three equivalent forms. Understanding this hierarchy is key to using dftly
+effectively:
+
+1. **String form** -- Concise, human-readable syntax designed for YAML configs. Parsed by a Lark grammar.
+
+    ```yaml
+    sum: $col1 + $col2 * 3
+    ```
+
+2. **Dict/YAML form** -- The fully explicit base form. Every node type, argument, and keyword argument is
+    spelled out. This is the canonical representation that all other forms reduce to.
+
+    ```yaml
+    sum:
+      add:
+        - column: col1
+        - multiply:
+            - column: col2
+            - literal: 3
+    ```
+
+3. **Class form** -- Python objects, isomorphic to the dict form. Used for programmatic construction.
+
+    ```python
+    Add(Column("col1"), Multiply(Column("col2"), Literal(3)))
+    ```
+
+**All three forms produce the same internal AST and the same Polars expression.** The string form is syntactic
+sugar over the dict form; any expression you can write as a string can also be written as an equivalent
+dict/YAML structure. When in doubt about what a string expression means, look at its dict form -- that is the
+unambiguous specification.
+
 ## Detailed Documentation
 
 Internally, this simply parses the yaml file into a mapping, then treats the mapping as a map from desired

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -234,9 +234,9 @@ class RegexExtract(KwargsOnlyFn):
 class RegexMatch(KwargsOnlyFn):
     """This node matches a regex pattern against a target node.
 
-    This node only accepts keyword arguments, and requires "pattern" and "from" keys. The "pattern" key is the
-    regex pattern to match, and the "from" key is the target node to match against. The result is a boolean
-    indicating whether the pattern matches the target.
+    This node only accepts keyword arguments, and requires "pattern" and "source" keys. The "pattern" key is
+    the regex pattern to match, and the "source" key is the target node to match against. The result is a
+    boolean indicating whether the pattern matches the target.
 
     Example:
         >>> from dftly.nodes import Literal, Column


### PR DESCRIPTION
## Summary
- Rewrite AGENTS.md with accurate architecture, the form hierarchy design principle, and guidance for AI agents
- Add Design Philosophy section to README explaining the three equivalent forms
- Fix RegexMatch docstring bug (said "from" kwarg but it's "source")
- Fix CONTRIBUTING.md copy-paste errors from MEDS_extract

## Why

The old AGENTS.md referenced files and APIs that no longer exist (`nodes.py`, `polars.py`, `grammar.lark` at root, `from_yaml()`, old enum-style expression names). More importantly, it didn't document the core design principle that all forms must reduce to the same base-form tree -- the principle we just applied when reviewing PR #51.

The new AGENTS.md includes:
- The form hierarchy principle with a concrete violation example
- Accurate project structure and parsing pipeline
- Node class hierarchy and registration guide
- Checklist for adding new node types
- Key conventions and common pitfalls

## Test plan
- [x] All 49 tests pass (including README doctests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)