### PR TITLE
Release: merge dev into main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ explicit.
 
 ```
 src/dftly/
-  __init__.py          -- Public API: Parser, extract_columns
+  __init__.py          -- Public API: Parser
   parser.py            -- Parser class (dict/YAML/string -> Node objects)
   nodes/
     __init__.py         -- Node registration (NODES dict, BINARY_OPS, UNARY_OPS)
@@ -239,7 +239,7 @@ pre-commit run --all-files
 | File                              | Purpose                                                |
 | --------------------------------- | ------------------------------------------------------ |
 | `src/dftly/__init__.py`           | Public API exports                                     |
-| `src/dftly/parser.py`             | Parser class, `extract_columns`, `is_expression`       |
+| `src/dftly/parser.py`             | Parser class and YAML/dict entry points                |
 | `src/dftly/nodes/base.py`         | NodeBase hierarchy and terminal nodes                  |
 | `src/dftly/nodes/__init__.py`     | Node registration (`NODES`, `BINARY_OPS`, `UNARY_OPS`) |
 | `src/dftly/str_form/grammar.lark` | LALR(1) expression grammar                             |

--- a/src/dftly/__init__.py
+++ b/src/dftly/__init__.py
@@ -1,2 +1,1 @@
 from .parser import Parser as Parser
-from .parser import extract_columns as extract_columns

--- a/src/dftly/parser.py
+++ b/src/dftly/parser.py
@@ -1,6 +1,5 @@
 from .nodes.base import NodeBase
 from pathlib import Path
-import re
 import warnings
 import polars as pl
 from .nodes import NODES
@@ -11,33 +10,6 @@ from .str_form.parser import DftlyGrammar
 import yaml
 
 SafeLoader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
-
-_COLUMN_RE = re.compile(r"\$([A-Za-z_]\w*)")
-
-
-def extract_columns(expr: str) -> set[str]:
-    """Extract column names referenced in a dftly expression string.
-
-    This uses a lightweight regex scan for ``$identifier`` patterns, so it works without parsing the
-    expression. Useful when you need to know which columns an expression depends on before building a schema.
-
-    Args:
-        expr: A dftly expression string.
-
-    Returns:
-        A set of column names.
-
-    Examples:
-        >>> sorted(extract_columns("$a + $b * 3"))
-        ['a', 'b']
-        >>> extract_columns("f'hello {$name}'")
-        {'name'}
-        >>> extract_columns("1 + 2")
-        set()
-        >>> sorted(extract_columns("$col1 > 0 and $col2 != $col1"))
-        ['col1', 'col2']
-    """
-    return set(_COLUMN_RE.findall(expr))
 
 
 class Parser:


### PR DESCRIPTION
## Summary

Rolls up dev into main. One change since the last main release:

- **Remove \`extract_columns\`** (#60, #61) — deleted the regex-based column-extraction shortcut in favor of \`NodeBase.referenced_columns\`, which walks the parsed AST and returns an authoritative set.

**Breaking:** \`from dftly import extract_columns\` no longer works. Migration: \`Parser()(expr).referenced_columns\`.

## Test plan

- [x] \`uv run pytest -x\` — 53 passed on dev
- [x] 100% coverage preserved
- [ ] CI green on this PR before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)