### PR TITLE
Add datetime/duration accessors with cast-syntax dispatch (#65)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 import polars as pl
@@ -17,6 +17,7 @@ def __setup_doctest_namespace(
     doctest_namespace.update(
         {
             "datetime": datetime,
+            "timedelta": timedelta,
             "tempfile": tempfile,
             "os": os,
             "pl": pl,

--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -23,7 +23,27 @@ from .comparison import (
     GreaterThanOrEqual,
     LessThanOrEqual,
 )
-from .datetime import SetTime
+from .datetime import (
+    SetTime,
+    _DtAccessor,
+    DtYear,
+    DtMonthOfYear,
+    DtDayOfMonth,
+    DtDayOfWeek,
+    DtDayOfYear,
+    DtHourOfDay,
+    DtMinuteOfHour,
+    DtSecondOfMinute,
+    DtWeekOfYear,
+    DtQuarterOfYear,
+    DtTotalSeconds,
+    DtTotalMilliseconds,
+    DtTotalMicroseconds,
+    DtTotalNanoseconds,
+    DtTotalMinutes,
+    DtTotalHours,
+    DtTotalDays,
+)
 from .str import StringInterpolate, RegexExtract, RegexMatch, Strptime
 from .conditional import Conditional
 from .types import Cast
@@ -58,6 +78,23 @@ __nodes = [
     Cast,
     Strptime,
     SetTime,
+    DtYear,
+    DtMonthOfYear,
+    DtDayOfMonth,
+    DtDayOfWeek,
+    DtDayOfYear,
+    DtHourOfDay,
+    DtMinuteOfHour,
+    DtSecondOfMinute,
+    DtWeekOfYear,
+    DtQuarterOfYear,
+    DtTotalSeconds,
+    DtTotalMilliseconds,
+    DtTotalMicroseconds,
+    DtTotalNanoseconds,
+    DtTotalMinutes,
+    DtTotalHours,
+    DtTotalDays,
 ]
 
 NODES = NodeBase.unique_dict_by_prop(__nodes)
@@ -71,3 +108,12 @@ BINARY_OPS = NodeBase.unique_dict_by_prop(__binary_ops, "SYM")
 
 __unary_ops = [node for node in __nodes if issubclass(node, UnaryOp)]
 UNARY_OPS = NodeBase.unique_dict_by_prop(__unary_ops, "SYM")
+
+# Datetime/duration accessors reachable via `::<name>` cast syntax. Built by scanning every
+# `_DtAccessor` subclass with a non-None ``CAST_NAME``; ``DtYear`` is excluded because
+# ``::year`` is already the integer→date cast (see ``nodes.types.Cast``).
+DT_CAST_ACCESSORS: dict[str, type] = {
+    cls.CAST_NAME: cls
+    for cls in __nodes
+    if issubclass(cls, _DtAccessor) and cls.CAST_NAME is not None
+}

--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -46,7 +46,7 @@ from .datetime import (
 )
 from .str import StringInterpolate, RegexExtract, RegexMatch, Strptime
 from .conditional import Conditional
-from .types import Cast
+from .types import Cast, TYPES
 
 __nodes = [
     Literal,
@@ -109,11 +109,32 @@ BINARY_OPS = NodeBase.unique_dict_by_prop(__binary_ops, "SYM")
 __unary_ops = [node for node in __nodes if issubclass(node, UnaryOp)]
 UNARY_OPS = NodeBase.unique_dict_by_prop(__unary_ops, "SYM")
 
-# Datetime/duration accessors reachable via `::<name>` cast syntax. Built by scanning every
-# `_DtAccessor` subclass with a non-None ``CAST_NAME``; ``DtYear`` is excluded because
-# ``::year`` is already the integer→date cast (see ``nodes.types.Cast``).
-DT_CAST_ACCESSORS: dict[str, type] = {
-    cls.CAST_NAME: cls
-    for cls in __nodes
-    if issubclass(cls, _DtAccessor) and cls.CAST_NAME is not None
-}
+
+# Datetime/duration accessors reachable via `::<name>` cast syntax. Built from the nodes
+# registered in ``__nodes`` that subclass ``_DtAccessor`` and declare a non-None
+# ``CAST_NAME``. ``DtYear`` uses ``::year_of_date`` rather than ``::year`` because
+# ``::year`` is already the integer→date cast (see ``nodes.types.Cast``). The builder
+# raises at import time if any ``CAST_NAME`` collides with another accessor or with a
+# registered type/unit in ``types.TYPES``, so cast-syntax dispatch can never be silently
+# shadowed by a future addition to either side.
+def _build_dt_cast_accessors() -> dict[str, type]:
+    accessors: dict[str, type] = {}
+    for cls in __nodes:
+        if not issubclass(cls, _DtAccessor) or cls.CAST_NAME is None:
+            continue
+        if cls.CAST_NAME in accessors:
+            raise ValueError(
+                f"Duplicate datetime cast accessor name {cls.CAST_NAME!r}: "
+                f"{accessors[cls.CAST_NAME].__name__} and {cls.__name__}"
+            )
+        if cls.CAST_NAME in TYPES:
+            raise ValueError(
+                f"Datetime cast accessor name {cls.CAST_NAME!r} for "
+                f"{cls.__name__} collides with a registered type/unit in "
+                f"nodes.types.TYPES"
+            )
+        accessors[cls.CAST_NAME] = cls
+    return accessors
+
+
+DT_CAST_ACCESSORS: dict[str, type] = _build_dt_cast_accessors()

--- a/src/dftly/nodes/datetime.py
+++ b/src/dftly/nodes/datetime.py
@@ -105,26 +105,38 @@ class _DtAccessor(ArgsOnlyFn):
 class DtYear(_DtAccessor):
     """Extract the calendar year (e.g. ``2024``) from a datetime or date.
 
-    **Cast form unavailable**: ``::year`` is already the integer→date construction
-    (``2024::year`` → ``date(2024, 1, 1)``). Use ``dt_year($event)`` in function-call form
-    instead.
+    The cast form is ``::year_of_date``, not ``::year``: ``::year`` is already the
+    integer→date construction (``2024::year`` → ``date(2024, 1, 1)``). The
+    ``year_of_date`` name keeps the direction unambiguous — "the year component of a
+    date" — and stays consistent with the ``_of_`` naming pattern used by the rest of
+    the datetime accessor family.
 
     Example:
         >>> from dftly.nodes import Literal
         >>> pl.select(DtYear(Literal(datetime(2024, 6, 15, 14, 30))).polars_expr).item()
         2024
 
-    Function-call string form:
+    Cast form:
 
         >>> from dftly import Parser
         >>> df = pl.DataFrame({"event": [datetime(2024, 6, 15, 14, 30)]})
+        >>> df.select(y=Parser.expr_to_polars("$event::year_of_date"))["y"].item()
+        2024
+
+    Function form:
+
         >>> df.select(y=Parser.expr_to_polars("dt_year($event)"))["y"].item()
         2024
+
+    ``::year`` still resolves to the integer→date constructor, not this accessor:
+
+        >>> pl.select(Parser.expr_to_polars("2024::year")).item()
+        datetime.date(2024, 1, 1)
     """
 
     KEY = "dt_year"
     PL_METHOD = "year"
-    # CAST_NAME intentionally None — `::year` is already int→date construction.
+    CAST_NAME = "year_of_date"
 
 
 class DtMonthOfYear(_DtAccessor):

--- a/src/dftly/nodes/datetime.py
+++ b/src/dftly/nodes/datetime.py
@@ -1,6 +1,8 @@
-"""Nodes relating to dates and times."""
+"""Nodes relating to dates, times, and durations."""
 
-from .base import BinaryOp
+from typing import ClassVar
+
+from .base import ArgsOnlyFn, BinaryOp
 import polars as pl
 
 
@@ -31,3 +33,373 @@ class SetTime(BinaryOp):
         date_expr = self.args[0].polars_expr
         time_expr = self.args[1].polars_expr
         return date_expr.dt.combine(time_expr)
+
+
+class _DtAccessor(ArgsOnlyFn):
+    """Base class for datetime and duration accessor nodes.
+
+    Each subclass wraps a single argument and delegates to
+    ``input.polars_expr.dt.<PL_METHOD>()``. Two families of subclasses live here:
+
+    - **Datetime component extraction** (Datetime → int): hour-of-day, day-of-month, etc.
+    - **Duration total** (Duration → int/float): total seconds, total days, etc.
+
+    Each subclass defines:
+
+    - ``KEY``: the function-call and dict-form name (e.g. ``"dt_hour_of_day"``).
+      Prefixed with ``dt_`` to prevent collisions with unrelated nodes.
+    - ``PL_METHOD``: the polars ``.dt.*`` method name (e.g. ``"hour"``).
+    - ``CAST_NAME``: the RHS name accepted by ``::`` cast syntax (e.g. ``"hour_of_day"``).
+      May be ``None`` if cast form is unavailable (e.g. ``DtYear`` — ``::year`` is already
+      the integer→date cast).
+
+    The shared arity-1 validation, ``from_lark`` wrapping, and ``polars_expr`` dispatch all
+    live here. Subclasses are typically four lines each.
+
+    Shared arity validation (exercised here so subclasses don't need to repeat the doctest):
+
+        >>> from dftly.nodes import Literal
+        >>> DtHourOfDay(Literal(datetime(2024, 1, 1, 14, 30)), Literal(datetime(2024, 1, 2)))
+        Traceback (most recent call last):
+            ...
+        ValueError: dt_hour_of_day requires exactly one argument; got 2
+        >>> DtTotalSeconds()
+        Traceback (most recent call last):
+            ...
+        ValueError: dt_total_seconds requires exactly one argument; got 0
+
+    Shared ``from_lark`` accepts both list and non-list inputs, consistent with ``Hash``:
+
+        >>> DtHourOfDay.from_lark([{"literal": {"datetime": datetime(2024, 1, 1, 14, 30)}}])
+        {'dt_hour_of_day': [{'literal': {'datetime': datetime.datetime(2024, 1, 1, 14, 30)}}]}
+        >>> DtHourOfDay.from_lark({"literal": {"datetime": datetime(2024, 1, 1, 14, 30)}})
+        {'dt_hour_of_day': [{'literal': {'datetime': datetime.datetime(2024, 1, 1, 14, 30)}}]}
+    """
+
+    PL_METHOD: ClassVar[str]
+    CAST_NAME: ClassVar[str | None] = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        if len(self.args) != 1:
+            raise ValueError(
+                f"{self.KEY} requires exactly one argument; got {len(self.args)}"
+            )
+
+    @classmethod
+    def from_lark(cls, items):
+        if not isinstance(items, list):
+            items = [items]
+        return {cls.KEY: items}
+
+    @property
+    def polars_expr(self) -> pl.Expr:
+        return getattr(self.args[0].polars_expr.dt, self.PL_METHOD)()
+
+
+# ---------------------------------------------------------------------------
+# Datetime component accessors
+# ---------------------------------------------------------------------------
+
+
+class DtYear(_DtAccessor):
+    """Extract the calendar year (e.g. ``2024``) from a datetime or date.
+
+    **Cast form unavailable**: ``::year`` is already the integer→date construction
+    (``2024::year`` → ``date(2024, 1, 1)``). Use ``dt_year($event)`` in function-call form
+    instead.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtYear(Literal(datetime(2024, 6, 15, 14, 30))).polars_expr).item()
+        2024
+
+    Function-call string form:
+
+        >>> from dftly import Parser
+        >>> df = pl.DataFrame({"event": [datetime(2024, 6, 15, 14, 30)]})
+        >>> df.select(y=Parser.expr_to_polars("dt_year($event)"))["y"].item()
+        2024
+    """
+
+    KEY = "dt_year"
+    PL_METHOD = "year"
+    # CAST_NAME intentionally None — `::year` is already int→date construction.
+
+
+class DtMonthOfYear(_DtAccessor):
+    """Extract the month (1-12) from a datetime or date.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtMonthOfYear(Literal(datetime(2024, 6, 15))).polars_expr).item()
+        6
+
+    Cast form:
+
+        >>> from dftly import Parser
+        >>> df = pl.DataFrame({"event": [datetime(2024, 6, 15)]})
+        >>> df.select(m=Parser.expr_to_polars("$event::month_of_year"))["m"].item()
+        6
+
+    Function form:
+
+        >>> df.select(m=Parser.expr_to_polars("dt_month_of_year($event)"))["m"].item()
+        6
+    """
+
+    KEY = "dt_month_of_year"
+    PL_METHOD = "month"
+    CAST_NAME = "month_of_year"
+
+
+class DtDayOfMonth(_DtAccessor):
+    """Extract the day-of-month (1-31) from a datetime or date.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtDayOfMonth(Literal(datetime(2024, 6, 15))).polars_expr).item()
+        15
+    """
+
+    KEY = "dt_day_of_month"
+    PL_METHOD = "day"
+    CAST_NAME = "day_of_month"
+
+
+class DtDayOfWeek(_DtAccessor):
+    """Extract the day-of-week (1=Monday, 7=Sunday) from a datetime or date.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtDayOfWeek(Literal(datetime(2024, 6, 15))).polars_expr).item()
+        6
+    """
+
+    KEY = "dt_day_of_week"
+    PL_METHOD = "weekday"
+    CAST_NAME = "day_of_week"
+
+
+class DtDayOfYear(_DtAccessor):
+    """Extract the ordinal day-of-year (1-366) from a datetime or date.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtDayOfYear(Literal(datetime(2024, 6, 15))).polars_expr).item()
+        167
+    """
+
+    KEY = "dt_day_of_year"
+    PL_METHOD = "ordinal_day"
+    CAST_NAME = "day_of_year"
+
+
+class DtHourOfDay(_DtAccessor):
+    """Extract the hour-of-day (0-23) from a datetime or time.
+
+    Motivating example from MEDS_transforms ``add_time_derived_measurements`` — entire
+    time-of-day bucketing logic reduces to a YAML ``Conditional`` once this accessor exists:
+
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtHourOfDay(Literal(datetime(2024, 6, 15, 14, 30))).polars_expr).item()
+        14
+
+    Cast form (the primary ergonomic path):
+
+        >>> from dftly import Parser
+        >>> df = pl.DataFrame({"event": [datetime(2024, 6, 15, 14, 30)]})
+        >>> df.select(h=Parser.expr_to_polars("$event::hour_of_day"))["h"].item()
+        14
+
+    Function form:
+
+        >>> df.select(h=Parser.expr_to_polars("dt_hour_of_day($event)"))["h"].item()
+        14
+    """
+
+    KEY = "dt_hour_of_day"
+    PL_METHOD = "hour"
+    CAST_NAME = "hour_of_day"
+
+
+class DtMinuteOfHour(_DtAccessor):
+    """Extract the minute-of-hour (0-59) from a datetime or time.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtMinuteOfHour(Literal(datetime(2024, 6, 15, 14, 30))).polars_expr).item()
+        30
+    """
+
+    KEY = "dt_minute_of_hour"
+    PL_METHOD = "minute"
+    CAST_NAME = "minute_of_hour"
+
+
+class DtSecondOfMinute(_DtAccessor):
+    """Extract the second-of-minute (0-59) from a datetime or time.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtSecondOfMinute(Literal(datetime(2024, 6, 15, 14, 30, 45))).polars_expr).item()
+        45
+    """
+
+    KEY = "dt_second_of_minute"
+    PL_METHOD = "second"
+    CAST_NAME = "second_of_minute"
+
+
+class DtWeekOfYear(_DtAccessor):
+    """Extract the ISO week-of-year (1-53) from a datetime or date.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtWeekOfYear(Literal(datetime(2024, 6, 15))).polars_expr).item()
+        24
+    """
+
+    KEY = "dt_week_of_year"
+    PL_METHOD = "week"
+    CAST_NAME = "week_of_year"
+
+
+class DtQuarterOfYear(_DtAccessor):
+    """Extract the quarter-of-year (1-4) from a datetime or date.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtQuarterOfYear(Literal(datetime(2024, 6, 15))).polars_expr).item()
+        2
+    """
+
+    KEY = "dt_quarter_of_year"
+    PL_METHOD = "quarter"
+    CAST_NAME = "quarter_of_year"
+
+
+# ---------------------------------------------------------------------------
+# Duration total accessors
+# ---------------------------------------------------------------------------
+
+
+class DtTotalSeconds(_DtAccessor):
+    """Project a Duration to total seconds (Duration → Int64).
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtTotalSeconds(Literal(timedelta(hours=2, minutes=30))).polars_expr).item()
+        9000
+
+    Cast form (the primary ergonomic path — dual to the existing ``42::seconds`` construction):
+
+        >>> from dftly import Parser
+        >>> df = pl.DataFrame({"t": [timedelta(hours=2, minutes=30)]})
+        >>> df.select(s=Parser.expr_to_polars("$t::total_seconds"))["s"].item()
+        9000
+    """
+
+    KEY = "dt_total_seconds"
+    PL_METHOD = "total_seconds"
+    CAST_NAME = "total_seconds"
+
+
+class DtTotalMilliseconds(_DtAccessor):
+    """Project a Duration to total milliseconds (Duration → Int64).
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtTotalMilliseconds(Literal(timedelta(seconds=1.5))).polars_expr).item()
+        1500
+    """
+
+    KEY = "dt_total_milliseconds"
+    PL_METHOD = "total_milliseconds"
+    CAST_NAME = "total_milliseconds"
+
+
+class DtTotalMicroseconds(_DtAccessor):
+    """Project a Duration to total microseconds (Duration → Int64).
+
+    Motivating example from MEDS_transforms ``add_time_derived_measurements/age.py``:
+    age computation as ``(event_time - dob) / <microseconds per year>``. Expressible
+    entirely in config once this accessor exists:
+
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtTotalMicroseconds(Literal(timedelta(days=1))).polars_expr).item()
+        86400000000
+
+    Cast-form via string parser, reproducing the MEDS age formula:
+
+        >>> from dftly import Parser
+        >>> df = pl.DataFrame({
+        ...     "event_time": [datetime(2030, 1, 1)],
+        ...     "dob":        [datetime(2000, 1, 1)],
+        ... })
+        >>> age_years = Parser.expr_to_polars(
+        ...     "($event_time - $dob)::total_microseconds / 31557600000000"
+        ... )
+        >>> round(df.select(age=age_years)["age"].item(), 4)
+        30.0014
+    """
+
+    KEY = "dt_total_microseconds"
+    PL_METHOD = "total_microseconds"
+    CAST_NAME = "total_microseconds"
+
+
+class DtTotalNanoseconds(_DtAccessor):
+    """Project a Duration to total nanoseconds (Duration → Int64).
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtTotalNanoseconds(Literal(timedelta(microseconds=1))).polars_expr).item()
+        1000
+    """
+
+    KEY = "dt_total_nanoseconds"
+    PL_METHOD = "total_nanoseconds"
+    CAST_NAME = "total_nanoseconds"
+
+
+class DtTotalMinutes(_DtAccessor):
+    """Project a Duration to total minutes (Duration → Int64).
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtTotalMinutes(Literal(timedelta(hours=2, minutes=30))).polars_expr).item()
+        150
+    """
+
+    KEY = "dt_total_minutes"
+    PL_METHOD = "total_minutes"
+    CAST_NAME = "total_minutes"
+
+
+class DtTotalHours(_DtAccessor):
+    """Project a Duration to total hours (Duration → Int64).
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtTotalHours(Literal(timedelta(days=1, hours=6))).polars_expr).item()
+        30
+    """
+
+    KEY = "dt_total_hours"
+    PL_METHOD = "total_hours"
+    CAST_NAME = "total_hours"
+
+
+class DtTotalDays(_DtAccessor):
+    """Project a Duration to total days (Duration → Int64).
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(DtTotalDays(Literal(timedelta(days=30, hours=12))).polars_expr).item()
+        30
+    """
+
+    KEY = "dt_total_days"
+    PL_METHOD = "total_days"
+    CAST_NAME = "total_days"

--- a/src/dftly/nodes/datetime.py
+++ b/src/dftly/nodes/datetime.py
@@ -49,9 +49,12 @@ class _DtAccessor(ArgsOnlyFn):
     - ``KEY``: the function-call and dict-form name (e.g. ``"dt_hour_of_day"``).
       Prefixed with ``dt_`` to prevent collisions with unrelated nodes.
     - ``PL_METHOD``: the polars ``.dt.*`` method name (e.g. ``"hour"``).
-    - ``CAST_NAME``: the RHS name accepted by ``::`` cast syntax (e.g. ``"hour_of_day"``).
-      May be ``None`` if cast form is unavailable (e.g. ``DtYear`` — ``::year`` is already
-      the integer→date cast).
+    - ``CAST_NAME``: the RHS name accepted by cast syntax in both ``::`` and ``as`` forms
+      (e.g. ``"hour_of_day"`` → ``$event::hour_of_day`` or ``$event as hour_of_day``).
+      Accessor dispatch is shared between both cast operators because they are semantically
+      equivalent in dftly and differ only in grammar precedence. May be ``None`` if no
+      cast form is wanted; set ``None`` when the accessor should only be reachable via
+      the function-call form (``dt_<name>($x)``).
 
     The shared arity-1 validation, ``from_lark`` wrapping, and ``polars_expr`` dispatch all
     live here. Subclasses are typically four lines each.
@@ -217,12 +220,24 @@ class DtHourOfDay(_DtAccessor):
         >>> pl.select(DtHourOfDay(Literal(datetime(2024, 6, 15, 14, 30))).polars_expr).item()
         14
 
-    Cast form (the primary ergonomic path):
+    Cast form (the primary ergonomic path) — works in both the ``::`` and ``as`` cast
+    forms, which are semantically equivalent in dftly and differ only in grammar
+    precedence (``::`` binds tight, ``as`` binds loose):
 
         >>> from dftly import Parser
         >>> df = pl.DataFrame({"event": [datetime(2024, 6, 15, 14, 30)]})
         >>> df.select(h=Parser.expr_to_polars("$event::hour_of_day"))["h"].item()
         14
+        >>> df.select(h=Parser.expr_to_polars("$event as hour_of_day"))["h"].item()
+        14
+
+    Both forms parse to the same accessor node:
+
+        >>> from dftly.str_form.parser import DftlyGrammar
+        >>> DftlyGrammar.parse_str("$event::hour_of_day")
+        {'dt_hour_of_day': [{'column': 'event'}]}
+        >>> DftlyGrammar.parse_str("$event as hour_of_day")
+        {'dt_hour_of_day': [{'column': 'event'}]}
 
     Function form:
 

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -12,6 +12,7 @@ from lark.visitors import Discard
 from ..nodes import (
     BINARY_OPS,
     UNARY_OPS,
+    DT_CAST_ACCESSORS,
     NODES,
     Cast,
     Literal,
@@ -292,4 +293,7 @@ class DftlyGrammar(Transformer):
 
     def cast_expr(self, items: list[Any]) -> dict:
         input, output_type = items
+        name = str(output_type)
+        if name in DT_CAST_ACCESSORS:
+            return DT_CAST_ACCESSORS[name].from_lark([input])
         return Cast.from_lark([input, Literal.from_lark(output_type)])


### PR DESCRIPTION
## Summary

Addresses #65. Implements the design from [the updated proposal comment](https://github.com/mmcdermott/dftly/issues/65#issuecomment-4241284376): a family of `_DtAccessor` subclasses covering datetime component extraction and duration projection, reachable via both function-call form and `::` / `as` cast-syntax form.

## What's new

**17 accessor classes** (all subclasses of a shared `_DtAccessor(ArgsOnlyFn)` base that holds the arity-1 check, `from_lark` wrapping, and `polars_expr` dispatch). Each subclass is ~4 lines.

| Class                    | KEY                     | CAST_NAME           | polars `.dt` method |
|--------------------------|-------------------------|---------------------|----------------------|
| `DtYear`                 | `dt_year`               | `year_of_date`      | `year`               |
| `DtMonthOfYear`          | `dt_month_of_year`      | `month_of_year`     | `month`              |
| `DtDayOfMonth`           | `dt_day_of_month`       | `day_of_month`      | `day`                |
| `DtDayOfWeek`            | `dt_day_of_week`        | `day_of_week`       | `weekday`            |
| `DtDayOfYear`            | `dt_day_of_year`        | `day_of_year`       | `ordinal_day`        |
| `DtHourOfDay`            | `dt_hour_of_day`        | `hour_of_day`       | `hour`               |
| `DtMinuteOfHour`         | `dt_minute_of_hour`     | `minute_of_hour`    | `minute`             |
| `DtSecondOfMinute`       | `dt_second_of_minute`   | `second_of_minute`  | `second`             |
| `DtWeekOfYear`           | `dt_week_of_year`       | `week_of_year`      | `week`               |
| `DtQuarterOfYear`        | `dt_quarter_of_year`    | `quarter_of_year`   | `quarter`            |
| `DtTotalSeconds`         | `dt_total_seconds`      | `total_seconds`     | `total_seconds`      |
| `DtTotalMilliseconds`    | `dt_total_milliseconds` | `total_milliseconds`| `total_milliseconds` |
| `DtTotalMicroseconds`    | `dt_total_microseconds` | `total_microseconds`| `total_microseconds` |
| `DtTotalNanoseconds`     | `dt_total_nanoseconds`  | `total_nanoseconds` | `total_nanoseconds`  |
| `DtTotalMinutes`         | `dt_total_minutes`      | `total_minutes`     | `total_minutes`      |
| `DtTotalHours`           | `dt_total_hours`        | `total_hours`       | `total_hours`        |
| `DtTotalDays`            | `dt_total_days`         | `total_days`        | `total_days`         |

**`DtYear` uses `year_of_date`, not `year`**, because `::year` is already the integer→date construction (`2024::year` → `date(2024, 1, 1)`). The `year_of_date` name keeps the direction unambiguous ("the year component of a date") and stays consistent with the `_of_` naming pattern used by the rest of the family. Both directions coexist: `2024::year` still constructs a date, and `$event::year_of_date` extracts the year.

## Naming rule

No new name collides with any existing `::` RHS:

- **Type coercion** *(existing)*: bare type names (`::int`, `::float`)
- **Duration construction** *(existing)*: plural unit names (`::days`, `::seconds`)
- **Duration projection** *(new)*: `total_`-prefixed unit names (`::total_seconds`)
- **Datetime component** *(new)*: `<field>_of_<period>` suffix (`::hour_of_day`, `::year_of_date`)

Every name belongs to exactly one family. `DT_CAST_ACCESSORS` is built at import time by `_build_dt_cast_accessors()`, which **raises** on either (a) duplicate `CAST_NAME` among accessors or (b) collision with any entry in `types.TYPES` — so cast-syntax dispatch can never be silently shadowed by a future addition on either side.

## How dispatch works

`src/dftly/str_form/parser.py`'s `cast_expr` transformer now checks `DT_CAST_ACCESSORS` before falling through to the existing `Cast` node:

```python
def cast_expr(self, items):
    input, output_type = items
    name = str(output_type)
    if name in DT_CAST_ACCESSORS:
        return DT_CAST_ACCESSORS[name].from_lark([input])
    return Cast.from_lark([input, Literal.from_lark(output_type)])
```

This transformer is shared between the `::` (`local_cast`) and `as` (`global_cast`) grammar rules, so both forms dispatch identically — `$event::hour_of_day` and `$event as hour_of_day` produce the same accessor node. The two cast forms have always been semantically equivalent in dftly and only differ in grammar precedence. This symmetry is locked in by doctests on `DtHourOfDay`.

**Adding a new accessor requires defining one class with three class attributes** — no parser changes, no grammar changes, no registry updates. The import-time collision guard then either accepts it or tells you exactly what it collides with.

## Motivating example

Age-in-years from MEDS_transforms `add_time_derived_measurements/age.py`, expressed entirely in string form:

```python
>>> df = pl.DataFrame({
...     "event_time": [datetime(2030, 1, 1)],
...     "dob":        [datetime(2000, 1, 1)],
... })
>>> age_years = Parser.expr_to_polars(
...     "($event_time - $dob)::total_microseconds / 31557600000000"
... )
>>> round(df.select(age=age_years)["age"].item(), 4)
30.0014
```

This lives in a `DtTotalMicroseconds` doctest.

## Test plan

- [x] `uv run pytest -x` — 71 passed (up from 53)
- [x] 100% coverage preserved
- [x] Each class has a working doctest on its `polars_expr`
- [x] `DtHourOfDay` doctests cover `::` and `as` cast forms plus function form, and assert parse-tree identity between `::` and `as`
- [x] Backwards compat verified: `2024::year` still constructs `date(2024, 1, 1)`, `3::days` still constructs a Duration, type coercion unchanged
- [x] `_DtAccessor` base docstring has error-case doctests (wrong arity, both `from_lark` branches)
- [x] Collision guard verified to raise on both modes (duplicate accessor name, collision with `TYPES`) via synthetic colliding classes

## What's not included

- **No grammar changes.** All families ride the existing `cast_expr` rule (shared between `::` and `as`).
- **No method-chaining syntax** (`$event.dt.hour()`). Same pushback as in #66 — function-call form has zero grammar cost and equivalent power.
- **No `DtTruncate`**. The issue author called it lower priority and it takes a Duration-string arg that's higher surface than this PR should cover. Easy follow-up.

Closes #65.
