### PR TITLE
Release 0.4.0: string length + substring + slice shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,46 @@ Every datetime/duration accessor also exists as a function-call form — `dt_hou
 `dt_total_seconds($delta)`, etc. — for use in programmatic construction or when the cast
 form doesn't compose cleanly. The two are always equivalent.
 
+### Position-based string operations
+
+`len_chars($col)` returns the Unicode character count of a string column, and
+`substring($col, start, stop)` returns a slice with Python-style `[start, stop)` semantics
+(inclusive start, exclusive stop; omit `stop` for "to end of string"). Negative indices
+count from the end, and the `$col[start:stop]` postfix shorthand parses to the same AST as
+the function form:
+
+```python
+>>> codes_df = pl.DataFrame({"code": ["12345", "1", "A420"]})
+>>> substring_ops = {
+...     "length": "len_chars($code)",
+...     "first_three": "$code[0:3]",
+...     "trailing": "$code[3:]",
+...     "last_two": "$code[-2:]",
+...     "dotted": 'f"{$code[0:3]}.{$code[3:]}" if len_chars($code) > 3 else $code',
+... }
+>>> codes_df.select(**Parser.to_polars(substring_ops))
+shape: (3, 5)
+┌────────┬─────────────┬──────────┬──────────┬────────┐
+│ length ┆ first_three ┆ trailing ┆ last_two ┆ dotted │
+│ ---    ┆ ---         ┆ ---      ┆ ---      ┆ ---    │
+│ u32    ┆ str         ┆ str      ┆ str      ┆ str    │
+╞════════╪═════════════╪══════════╪══════════╪════════╡
+│ 5      ┆ 123         ┆ 45       ┆ 45       ┆ 123.45 │
+│ 1      ┆ 1           ┆          ┆ 1        ┆ 1      │
+│ 4      ┆ A42         ┆ 0        ┆ 20       ┆ A42.0  │
+└────────┴─────────────┴──────────┴──────────┴────────┘
+
+```
+
+The `dotted` column above is the idiomatic translation of the Python guard-and-splice
+pattern used for ICD-code normalization: apply the dot only when the code is long enough,
+otherwise pass through unchanged. The length guard is what makes `substring` strictly more
+expressive than a pure-regex solution for this pattern.
+
+Slice step (`[i:j:k]`) and single-index subscription (`[i]`) are intentionally unsupported —
+polars' `str.slice` has no step, and single-index is expressible as `substring(expr, i, i+1)`.
+Both produce a clear parse error pointing at the supported forms.
+
 You can also add literal columns:
 
 ```python

--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -45,7 +45,14 @@ from .datetime import (
     DtTotalHours,
     DtTotalDays,
 )
-from .str import StringInterpolate, RegexExtract, RegexMatch, Strptime
+from .str import (
+    StringInterpolate,
+    RegexExtract,
+    RegexMatch,
+    Strptime,
+    LenChars,
+    Substring,
+)
 from .conditional import Conditional
 from .types import Cast, TYPES
 
@@ -76,6 +83,8 @@ __nodes = [
     StringInterpolate,
     RegexExtract,
     RegexMatch,
+    LenChars,
+    Substring,
     Conditional,
     Cast,
     Strptime,

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -654,7 +654,8 @@ class Substring(KwargsOnlyFn):
         >>> pl.select(empty.polars_expr).item()
         ''
 
-    Negative indices count from the end of the string:
+    Negative indices count from the end of the string, matching Python's slice
+    semantics even for mixed-sign and out-of-range bounds:
 
         >>> tail = Substring(source=Literal("abcdef"), start=Literal(-2))
         >>> pl.select(tail.polars_expr).item()
@@ -662,6 +663,18 @@ class Substring(KwargsOnlyFn):
         >>> middle = Substring(source=Literal("abcdef"), start=Literal(-4), stop=Literal(-1))
         >>> pl.select(middle.polars_expr).item()
         'cde'
+        >>> mixed_neg_pos = Substring(source=Literal("abcdef"), start=Literal(-4), stop=Literal(2))
+        >>> pl.select(mixed_neg_pos.polars_expr).item()
+        ''
+        >>> mixed_pos_neg = Substring(source=Literal("abcdef"), start=Literal(2), stop=Literal(-1))
+        >>> pl.select(mixed_pos_neg.polars_expr).item()
+        'cde'
+        >>> out_of_range = Substring(source=Literal("abcdef"), start=Literal(-100), stop=Literal(200))
+        >>> pl.select(out_of_range.polars_expr).item()
+        'abcdef'
+        >>> backward = Substring(source=Literal("abcdef"), start=Literal(5), stop=Literal(2))
+        >>> pl.select(backward.polars_expr).item()
+        ''
 
     It parses from string form via the function-call grammar, with 2 or 3 positional args:
 
@@ -774,10 +787,27 @@ class Substring(KwargsOnlyFn):
     def polars_expr(self) -> pl.Expr:
         source_expr = self.kwargs["source"].polars_expr
         start_expr = self.kwargs["start"].polars_expr
-        if "stop" in self.kwargs:
-            length_expr = self.kwargs["stop"].polars_expr - start_expr
-            return source_expr.str.slice(start_expr, length_expr)
-        return source_expr.str.slice(start_expr)
+        if "stop" not in self.kwargs:
+            # Open stop: polars' ``.str.slice(offset)`` matches Python's ``a[i:]``
+            # for both positive and negative offsets with no normalization needed.
+            return source_expr.str.slice(start_expr)
+        stop_expr = self.kwargs["stop"].polars_expr
+        # Python slice semantics: normalize negative bounds against ``len``, clip
+        # both to ``[0, len]``, then take ``length = stop - start``. Polars'
+        # ``.str.slice(offset, length)`` takes a signed offset (negative counts
+        # from end) but a non-negative length starting at that offset, so a naive
+        # ``stop - start`` is wrong for mixed-sign or out-of-range bounds — e.g.
+        # ``"abcdef"[-4:2]`` is ``""`` in Python but would ask polars for offset
+        # ``-4``, length ``6``, returning ``"cdef"``. We normalize first.
+        str_len = source_expr.str.len_chars().cast(pl.Int64)
+        norm_start = (
+            pl.when(start_expr < 0).then(start_expr + str_len).otherwise(start_expr)
+        ).clip(0, str_len)
+        norm_stop = (
+            pl.when(stop_expr < 0).then(stop_expr + str_len).otherwise(stop_expr)
+        ).clip(0, str_len)
+        length = (norm_stop - norm_start).clip(0)
+        return source_expr.str.slice(norm_start, length)
 
     @classmethod
     def from_lark(cls, items: list[Any]) -> dict[str, Any]:

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -673,18 +673,83 @@ class Substring(KwargsOnlyFn):
         >>> DftlyGrammar.parse_str("substring($code, 3)")
         {'substring': {'source': {'column': 'code'}, 'start': {'literal': 3}}}
 
+    Python-style ``[start:stop]`` postfix shorthand produces the same AST as the function
+    form. All four Python slice shapes are supported; omitted endpoints default to 0 for
+    ``start`` and "to end of string" for ``stop``:
+
+        >>> DftlyGrammar.parse_str("$code[0:3]")
+        {'substring': {'source': {'column': 'code'},
+                       'start': {'literal': 0},
+                       'stop': {'literal': 3}}}
+        >>> DftlyGrammar.parse_str("$code[3:]")
+        {'substring': {'source': {'column': 'code'}, 'start': {'literal': 3}}}
+        >>> DftlyGrammar.parse_str("$code[:3]")
+        {'substring': {'source': {'column': 'code'},
+                       'start': {'literal': 0},
+                       'stop': {'literal': 3}}}
+        >>> DftlyGrammar.parse_str("$code[:]")
+        {'substring': {'source': {'column': 'code'}, 'start': {'literal': 0}}}
+
+    Negative indices and expression-valued bounds work identically to the functional form:
+
+        >>> DftlyGrammar.parse_str("$code[-3:-1]")
+        {'substring': {'source': {'column': 'code'},
+                       'start': {'negate': [{'literal': 3}]},
+                       'stop': {'negate': [{'literal': 1}]}}}
+
+    The shorthand binds tighter than unary, so ``-$col[0:3]`` is ``-($col[0:3])`` (matching
+    Python). Chained subscripts apply left-to-right: ``$col[0:5][1:3]`` substrings the
+    substring.
+
+        >>> DftlyGrammar.parse_str("$code[0:5][1:3]")
+        {'substring': {'source': {'substring': {'source': {'column': 'code'},
+                                                'start': {'literal': 0},
+                                                'stop': {'literal': 5}}},
+                       'start': {'literal': 1},
+                       'stop': {'literal': 3}}}
+
+    The shorthand also applies to arbitrary parenthesized expressions, not just columns:
+
+        >>> DftlyGrammar.parse_str("($a + $b)[0:3]")
+        {'substring': {'source': {'add': [{'column': 'a'}, {'column': 'b'}]},
+                       'start': {'literal': 0},
+                       'stop': {'literal': 3}}}
+
+    Bounds that form a ``HH:MM`` pattern (e.g. ``[10:30]``) would otherwise be lexed as
+    a TIME literal by Lark's longest-match lexer; they're decomposed back into integer
+    bounds so the intuitive meaning holds:
+
+        >>> DftlyGrammar.parse_str("$code[10:30]")
+        {'substring': {'source': {'column': 'code'},
+                       'start': {'literal': 10},
+                       'stop': {'literal': 30}}}
+
+    Slice step is not supported (Polars' ``str.slice`` has no step); ``HH:MM:SS``-shaped
+    bounds with non-zero seconds raise a clear error pointing at the functional form:
+
+        >>> DftlyGrammar.parse_str("$code[10:30:45]")
+        Traceback (most recent call last):
+            ...
+        lark.exceptions.VisitError: ... Slice shorthand does not support step ...
+
     End-to-end: the MIMIC ICD dot-insertion pattern (``add_dot($code, 3)``) combines
     :class:`LenChars` and :class:`Substring` to produce a declarative equivalent of the
-    Python guard-and-splice idiom:
+    Python guard-and-splice idiom. Both the function and shorthand forms produce the same
+    result:
 
         >>> from dftly import Parser
-        >>> df = pl.DataFrame({"code": ["12345", "1"]})
-        >>> expr = Parser.expr_to_polars(
+        >>> df = pl.DataFrame({"code": ["12345", "1", "A420"]})
+        >>> func_expr = Parser.expr_to_polars(
         ...     'f"{substring($code, 0, 3)}.{substring($code, 3)}" '
         ...     'if len_chars($code) > 3 else $code'
         ... )
-        >>> df.select(expr).to_series().to_list()
-        ['123.45', '1']
+        >>> df.select(func_expr).to_series().to_list()
+        ['123.45', '1', 'A42.0']
+        >>> short_expr = Parser.expr_to_polars(
+        ...     'f"{$code[0:3]}.{$code[3:]}" if len_chars($code) > 3 else $code'
+        ... )
+        >>> df.select(short_expr).to_series().to_list()
+        ['123.45', '1', 'A42.0']
 
     Missing required kwargs raise an error:
 

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -562,3 +562,170 @@ class Strptime(KwargsOnlyFn):
         source, format = items
 
         return {cls.KEY: {"format": format, "source": source}}
+
+
+class LenChars(ArgsOnlyFn):
+    """This non-terminal node returns the character length of a string expression.
+
+    The result is a ``UInt32`` count of Unicode characters (not bytes). Name matches Polars'
+    ``pl.Expr.str.len_chars()``. This node is function-only (no operator form), so it subclasses
+    :class:`ArgsOnlyFn` with a single-arg check rather than :class:`UnaryOp` (which requires
+    a ``SYM`` for operator-form registration).
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> pl.select(LenChars(Literal("hello")).polars_expr).item()
+        5
+        >>> pl.select(LenChars(Literal("")).polars_expr).item()
+        0
+        >>> pl.select(LenChars(Literal("café")).polars_expr).item()
+        4
+
+    It parses from string form via the function-call grammar:
+
+        >>> from dftly import Parser
+        >>> df = pl.DataFrame({"code": ["12345", "1"]})
+        >>> df.select(Parser.expr_to_polars("len_chars($code)"))
+        shape: (2, 1)
+        ┌──────┐
+        │ code │
+        │ ---  │
+        │ u32  │
+        ╞══════╡
+        │ 5    │
+        │ 1    │
+        └──────┘
+
+    Parsing a function call yields a node whose short-form argument is a list containing the
+    inner column node:
+
+        >>> from dftly.str_form.parser import DftlyGrammar
+        >>> DftlyGrammar.parse_str("len_chars($code)")
+        {'len_chars': [{'column': 'code'}]}
+
+    Only one argument is accepted:
+
+        >>> LenChars(Literal("a"), Literal("b"))
+        Traceback (most recent call last):
+            ...
+        ValueError: len_chars requires exactly one argument; got 2
+    """
+
+    KEY = "len_chars"
+
+    def __post_init__(self):
+        super().__post_init__()
+        if len(self.args) != 1:
+            raise ValueError(
+                f"{self.KEY} requires exactly one argument; got {len(self.args)}"
+            )
+
+    @classmethod
+    def from_lark(cls, items):
+        if not isinstance(items, list):
+            items = [items]
+        return {cls.KEY: items}
+
+    @property
+    def polars_expr(self) -> pl.Expr:
+        return self.args[0].polars_expr.str.len_chars()
+
+
+class Substring(KwargsOnlyFn):
+    """This non-terminal node extracts a substring from a string expression.
+
+    Uses Python-style ``[start, stop)`` semantics: inclusive start, exclusive stop. An omitted
+    ``stop`` means "to end of string". Negative indices are honored (they count from the end).
+
+    Arguments:
+        source: the string expression to slice.
+        start: the index at which the substring begins (inclusive).
+        stop: optional index at which the substring ends (exclusive). If omitted, slices to end.
+
+    Example:
+        >>> from dftly.nodes import Literal
+        >>> substr = Substring(source=Literal("abcdef"), start=Literal(1), stop=Literal(4))
+        >>> pl.select(substr.polars_expr).item()
+        'bcd'
+        >>> to_end = Substring(source=Literal("abcdef"), start=Literal(2))
+        >>> pl.select(to_end.polars_expr).item()
+        'cdef'
+        >>> empty = Substring(source=Literal("abc"), start=Literal(0), stop=Literal(0))
+        >>> pl.select(empty.polars_expr).item()
+        ''
+
+    Negative indices count from the end of the string:
+
+        >>> tail = Substring(source=Literal("abcdef"), start=Literal(-2))
+        >>> pl.select(tail.polars_expr).item()
+        'ef'
+        >>> middle = Substring(source=Literal("abcdef"), start=Literal(-4), stop=Literal(-1))
+        >>> pl.select(middle.polars_expr).item()
+        'cde'
+
+    It parses from string form via the function-call grammar, with 2 or 3 positional args:
+
+        >>> from dftly.str_form.parser import DftlyGrammar
+        >>> DftlyGrammar.parse_str("substring($code, 0, 3)")
+        {'substring': {'source': {'column': 'code'},
+                       'start': {'literal': 0},
+                       'stop': {'literal': 3}}}
+        >>> DftlyGrammar.parse_str("substring($code, 3)")
+        {'substring': {'source': {'column': 'code'}, 'start': {'literal': 3}}}
+
+    End-to-end: the MIMIC ICD dot-insertion pattern (``add_dot($code, 3)``) combines
+    :class:`LenChars` and :class:`Substring` to produce a declarative equivalent of the
+    Python guard-and-splice idiom:
+
+        >>> from dftly import Parser
+        >>> df = pl.DataFrame({"code": ["12345", "1"]})
+        >>> expr = Parser.expr_to_polars(
+        ...     'f"{substring($code, 0, 3)}.{substring($code, 3)}" '
+        ...     'if len_chars($code) > 3 else $code'
+        ... )
+        >>> df.select(expr).to_series().to_list()
+        ['123.45', '1']
+
+    Missing required kwargs raise an error:
+
+        >>> Substring(source=Literal("abc"))
+        Traceback (most recent call last):
+            ...
+        ValueError: Missing required keys for substring: {'start'}
+
+    Extra kwargs raise an error:
+
+        >>> Substring(source=Literal("abc"), start=Literal(0), step=Literal(2))
+        Traceback (most recent call last):
+            ...
+        ValueError: Extra unallowed keys for substring: {'step'}
+    """
+
+    KEY = "substring"
+    REQUIRED_KWARGS = {"source", "start"}
+    OPTIONAL_KWARGS = {"stop"}
+
+    @property
+    def polars_expr(self) -> pl.Expr:
+        source_expr = self.kwargs["source"].polars_expr
+        start_expr = self.kwargs["start"].polars_expr
+        if "stop" in self.kwargs:
+            length_expr = self.kwargs["stop"].polars_expr - start_expr
+            return source_expr.str.slice(start_expr, length_expr)
+        return source_expr.str.slice(start_expr)
+
+    @classmethod
+    def from_lark(cls, items: list[Any]) -> dict[str, Any]:
+        if len(items) == 2:
+            kwargs = {"source": items[0], "start": items[1]}
+        elif len(items) == 3:
+            kwargs = {
+                "source": items[0],
+                "start": items[1],
+                "stop": items[2],
+            }
+        else:
+            raise ValueError(
+                f"substring expects 2 or 3 positional arguments; got {len(items)}"
+            )
+        return {cls.KEY: kwargs}

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -11,7 +11,8 @@
 //   8. exp_expr       — `**` (right-associative)
 //   9. local_cast     — `::type` / `::'%fmt'`
 //  10. unary          — `not`, `!`, unary `+`/`-`
-//  11. primary        — literals, columns, function calls, regex, parenthesized expressions
+//  11. postfix        — `[start:stop]` substring shorthand (binds tighter than unary)
+//  12. primary        — literals, columns, function calls, regex, parenthesized expressions
 //
 // Priority annotations (e.g. `.1`, `.2`) on terminals resolve lexer ambiguities:
 // higher priority terminals are preferred when multiple patterns match the same input.
@@ -52,6 +53,9 @@ AND_SYM: "&&"
 OR_SYM: "||"
 NOT_SYM: "!"
 QUESTION: "?"
+LBRACK: "["
+RBRACK: "]"
+COLON: ":"
 
 // Keywords — priority .2 ensures these are preferred over NAME
 FORMAT_PFX: "f"
@@ -121,7 +125,28 @@ FROM.2: /from/i
 
 ?unary: (NOT_SYM|NOT) unary   -> unary_expr
       | (PLUS|MINUS) unary    -> unary_expr
-      | primary
+      | postfix
+
+// Substring shorthand: `primary[start:stop]`. Binds tighter than unary so that
+// `-$a[0:3]` parses as `-($a[0:3])`, matching Python's subscription precedence.
+// Chained subscripts (`$a[0:5][1:3]`) are supported via the left-recursive rule.
+// The four `slice_spec` alternatives correspond to Python's four slice forms:
+//   `[i:j]`, `[i:]`, `[:j]`, `[:]`. Single-index `[i]` and step `[i:j:k]` are
+//   intentionally NOT supported — single-index means `substring(expr, i, i+1)`
+//   which is trivial to write as `substring(expr, i, i+1)`, and polars has no
+//   `str.slice` step. Both produce a parse error pointing at the unsupported form.
+// The `TIME`-shaped slice case (`[10:30]`) is handled by the `substring_slice_time`
+// rule below: lark's longest-match lexer prefers the 5-char TIME match over the
+// 2-char INT, so we decompose the TIME back into (HH, MM) bounds in the transformer.
+// `HH:MM:SS`-shaped tokens raise a clear "step not supported" error.
+?postfix: postfix LBRACK slice_spec RBRACK  -> substring_postfix
+        | primary
+
+?slice_spec: expr COLON expr   -> substring_slice_full
+           | expr COLON        -> substring_slice_from
+           | COLON expr        -> substring_slice_to
+           | COLON             -> substring_slice_all
+           | TIME              -> substring_slice_time
 
 ?paren_group: "(" expr ")"
 

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -84,7 +84,7 @@ FROM.2: /from/i
 ?global_cast: conditional AS NAME   -> cast_expr
             | conditional AS STRING -> strptime
             | conditional AS QUESTION STRING -> strptime_nonstrict
-            | conditional AT TIME   -> binary_expr
+            | conditional AT time_literal   -> binary_expr
             | conditional
 
 ?conditional: expr IF expr (ELSE expr)?   -> conditional
@@ -160,7 +160,7 @@ FROM.2: /from/i
         | call_expr
         | (DOLLAR)NAME -> column
         | (FORMAT_PFX)STRING -> string_interpolate
-        | TIME
+        | time_literal
         | DATE
         | DATETIME
         | NUMBER
@@ -168,3 +168,11 @@ FROM.2: /from/i
         | STRING
         | NAME -> bare_word
         | paren_group
+
+// TIME is parsed at rule level rather than via a terminal-level transformer so that
+// the raw `TIME` Token remains accessible in contexts where we need to distinguish
+// `HH:MM` (a valid 2-bound substring slice) from `HH:MM:SS` (an unambiguous step
+// request, not supported). The rule-level `time_literal` handler converts the token
+// into a Literal dict for every context that wants a parsed value; the slice-spec
+// handler operates on the raw token directly.
+time_literal: TIME  -> time_literal

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -135,10 +135,12 @@ FROM.2: /from/i
 //   intentionally NOT supported — single-index means `substring(expr, i, i+1)`
 //   which is trivial to write as `substring(expr, i, i+1)`, and polars has no
 //   `str.slice` step. Both produce a parse error pointing at the unsupported form.
-// The `TIME`-shaped slice case (`[10:30]`) is handled by the `substring_slice_time`
-// rule below: lark's longest-match lexer prefers the 5-char TIME match over the
-// 2-char INT, so we decompose the TIME back into (HH, MM) bounds in the transformer.
-// `HH:MM:SS`-shaped tokens raise a clear "step not supported" error.
+// The `TIME`-shaped slice case (`[10:30]`) needs the extra alternative below
+// because lark's longest-match lexer prefers the 5-char TIME match over the
+// 2-char INT, so `10:30` never reaches the `expr COLON expr` alternative. TIME
+// is parsed at the rule level (see `time_literal` and LITERAL_PARSERS comment in
+// parser.py) so the raw Token flows into `substring_slice_time`, which splits
+// on `:` — 2 parts is a valid `HH:MM` slice, 3 parts is an unsupported step.
 ?postfix: postfix LBRACK slice_spec RBRACK  -> substring_postfix
         | primary
 

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -202,11 +202,13 @@ class DftlyGrammar(Transformer):
 
         return cls().transform(tree)
 
+    # TIME intentionally omitted: parsed at the rule level via ``time_literal`` so the
+    # raw Token remains accessible to the substring slice-spec handler, which needs to
+    # distinguish `HH:MM` (valid 2-bound slice) from `HH:MM:SS` (unsupported step).
     LITERAL_PARSERS = {
         "INT": int,
         "NUMBER": lambda x: float(x) if "." in x or "e" in x.lower() else int(x),
         "BOOL": lambda x: x.lower() == "true",
-        "TIME": lambda x: dt_parser.parse(x).time(),
         "DATE": lambda x: dt_parser.parse(x).date(),
         "DATETIME": dt_parser.parse,
         "STRING": lambda x: x[1:-1],  # Remove surrounding quotes
@@ -322,23 +324,32 @@ class DftlyGrammar(Transformer):
     def substring_slice_all(self, items: list[Any]) -> dict:
         return {"start": Literal.from_lark(0)}
 
+    def time_literal(self, items: list[Any]) -> dict:
+        # TIME terminal is not in ``LITERAL_PARSERS`` so we receive the raw Token;
+        # convert it to a Literal dict here for every non-slice context.
+        (token,) = items
+        try:
+            return Literal.from_lark(dt_parser.parse(str(token)).time())
+        except Exception as e:
+            raise ValueError(f"Failed to parse literal {token}") from e
+
     def substring_slice_time(self, items: list[Any]) -> dict:
         # Lark's longest-match lexer prefers TIME over INT:COLON:INT when both bounds
-        # are 2-digit integers matching `HH:MM` (e.g. `$a[10:30]`). By the time we
-        # get here, the TIME terminal has already been transformed into a literal
-        # `datetime.time`, so we decompose the time object back into integer bounds.
-        # `HH:MM:SS` (step) cannot be distinguished from `HH:MM` when SS==0 (both
-        # parse to `time(h, m, 0)`); we treat that collision as a slice. Non-zero
-        # SS is an unambiguous step request and raises.
-        (time_dict,) = items
-        t = time_dict["literal"]
-        if t.second != 0:
-            raise ValueError(
-                f"Slice shorthand does not support step "
-                f"(got '{t.hour}:{t.minute:02d}:{t.second:02d}'); "
-                f"use the substring() function form."
-            )
-        return {
-            "start": Literal.from_lark(t.hour),
-            "stop": Literal.from_lark(t.minute),
-        }
+        # are 2-digit integers matching `HH:MM` (e.g. `$a[10:30]`). We receive the raw
+        # TIME Token here (no terminal-level transform — see ``LITERAL_PARSERS``) and
+        # split on ``:`` to count components. Two parts → 2-bound slice. Three parts
+        # (``HH:MM:SS``) → step, not supported. An AM/PM suffix is stripped defensively
+        # — it's grammatically permitted by the TIME regex but meaningless in a slice.
+        (token,) = items
+        raw = str(token)
+        parts = raw.split()[0].split(":")
+        if len(parts) == 2:
+            hh, mm = parts
+            return {
+                "start": Literal.from_lark(int(hh)),
+                "stop": Literal.from_lark(int(mm)),
+            }
+        raise ValueError(
+            f"Slice shorthand does not support step (got {raw!r}); "
+            f"use the substring() function form."
+        )

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -243,6 +243,7 @@ class DftlyGrammar(Transformer):
 
     IF = ELSE = EXTRACT = GROUP = OF = FROM = IN = CAST = AS = _discard_token
     FORMAT_PFX = DOLLAR = QUESTION = _discard_token
+    LBRACK = RBRACK = COLON = _discard_token
 
     def NAME(self, val: Token) -> str:
         return str(val)
@@ -297,3 +298,47 @@ class DftlyGrammar(Transformer):
         if name in DT_CAST_ACCESSORS:
             return DT_CAST_ACCESSORS[name].from_lark([input])
         return Cast.from_lark([input, Literal.from_lark(output_type)])
+
+    # Substring shorthand `$col[start:stop]` → Substring(source, start, stop).
+    # The four `substring_slice_*` methods return kwargs dicts without a `source`;
+    # `substring_postfix` fills in `source` from the subscripted expression.
+    def substring_postfix(self, items: list[Any]) -> dict:
+        source, slice_kwargs = items
+        slice_kwargs = {"source": source, **slice_kwargs}
+        return {"substring": slice_kwargs}
+
+    def substring_slice_full(self, items: list[Any]) -> dict:
+        start, stop = items
+        return {"start": start, "stop": stop}
+
+    def substring_slice_from(self, items: list[Any]) -> dict:
+        (start,) = items
+        return {"start": start}
+
+    def substring_slice_to(self, items: list[Any]) -> dict:
+        (stop,) = items
+        return {"start": Literal.from_lark(0), "stop": stop}
+
+    def substring_slice_all(self, items: list[Any]) -> dict:
+        return {"start": Literal.from_lark(0)}
+
+    def substring_slice_time(self, items: list[Any]) -> dict:
+        # Lark's longest-match lexer prefers TIME over INT:COLON:INT when both bounds
+        # are 2-digit integers matching `HH:MM` (e.g. `$a[10:30]`). By the time we
+        # get here, the TIME terminal has already been transformed into a literal
+        # `datetime.time`, so we decompose the time object back into integer bounds.
+        # `HH:MM:SS` (step) cannot be distinguished from `HH:MM` when SS==0 (both
+        # parse to `time(h, m, 0)`); we treat that collision as a slice. Non-zero
+        # SS is an unambiguous step request and raises.
+        (time_dict,) = items
+        t = time_dict["literal"]
+        if t.second != 0:
+            raise ValueError(
+                f"Slice shorthand does not support step "
+                f"(got '{t.hour}:{t.minute:02d}:{t.second:02d}'); "
+                f"use the substring() function form."
+            )
+        return {
+            "start": Literal.from_lark(t.hour),
+            "stop": Literal.from_lark(t.minute),
+        }


### PR DESCRIPTION
## Summary

Release candidate for 0.4.0. Contains the single feature PR merged into dev since 0.3.0:

- **#73** — Adds `len_chars` and `substring` nodes, plus the `$col[start:stop]` postfix shorthand. Python-style slice semantics (negatives, mixed-sign, out-of-range bounds all normalized against string length). Closes #72.

## Version bump rationale

Minor bump (0.3.0 → 0.4.0): new user-facing surface (two nodes + grammar shorthand), no breaking changes. One internal refactor (TIME parsed at rule level vs. terminal level) preserves all prior behavior in non-slice contexts.

## Test plan

- [x] `uv run pytest --ignore=docs` green on dev (74 tests).
- [ ] CI green on this RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)