### PR TITLE
Add `??` null-coalescing operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,39 @@ Slice step (`[i:j:k]`) and single-index subscription (`[i]`) are intentionally u
 polars' `str.slice` has no step, and single-index is expressible as `substring(expr, i, i+1)`.
 Both produce a clear parse error pointing at the supported forms.
 
+### Null-coalescing with `??`
+
+The `??` operator returns its first non-null operand, so it's the concise way to substitute a
+sentinel for nulls. It is pure sugar for the [`coalesce`](#detailed-documentation) node — `$a ?? UNK` parses to exactly the same tree as `coalesce($a, UNK)` — and works anywhere an expression
+is allowed, including inside `f"{...}"` string interpolation (where each field is itself a full
+expression). This makes it easy to guard interpolated columns against nulls:
+
+```python
+>>> null_df = pl.DataFrame({"a": ["x", None], "b": [None, "y"], "n": [None, 5]})
+>>> coalesce_ops = {
+...     "filled": "$a ?? 'UNK'",
+...     "count": "$n ?? 0",
+...     "first_present": "$a ?? $b ?? 'UNK'",
+...     "joined": '''f"{$a ?? 'UNK'}//{$b ?? 'UNK'}"''',
+... }
+>>> null_df.select(**Parser.to_polars(coalesce_ops))
+shape: (2, 4)
+┌────────┬───────┬───────────────┬────────┐
+│ filled ┆ count ┆ first_present ┆ joined │
+│ ---    ┆ ---   ┆ ---           ┆ ---    │
+│ str    ┆ i64   ┆ str           ┆ str    │
+╞════════╪═══════╪═══════════════╪════════╡
+│ x      ┆ 0     ┆ x             ┆ x//UNK │
+│ UNK    ┆ 5     ┆ y             ┆ UNK//y │
+└────────┴───────┴───────────────┴────────┘
+
+```
+
+`??` is left-associative and binds looser than the boolean operators (matching C#/JS), so
+`$x or $y ?? $z` groups as `($x or $y) ?? $z`. Chains like `$a ?? $b ?? UNK` nest as
+`coalesce(coalesce($a, $b), UNK)`, which returns the same first-non-null result as the flat
+`coalesce($a, $b, UNK)`.
+
 You can also add literal columns:
 
 ```python

--- a/src/dftly/nodes/arithmetic.py
+++ b/src/dftly/nodes/arithmetic.py
@@ -390,6 +390,36 @@ class Coalesce(ArgsOnlyFn):
         1
         >>> pl.select(Coalesce(Literal(3), Literal(None)).polars_expr).item()
         3
+
+    In string form, the ``??`` null-coalescing operator is sugar for this node: ``$a ?? b``
+    parses to exactly the same base form as the function call ``coalesce($a, b)``. This is the
+    idiomatic way to substitute a sentinel for nulls, including inside f-string interpolation:
+
+        >>> from dftly.str_form.parser import DftlyGrammar
+        >>> DftlyGrammar.parse_str("$a ?? 'UNK'")
+        {'coalesce': [{'column': 'a'}, {'literal': 'UNK'}]}
+        >>> DftlyGrammar.parse_str("$a ?? 'UNK'") == DftlyGrammar.parse_str("coalesce($a, 'UNK')")
+        True
+
+    ``??`` is left-associative, so chains nest just like ``+`` or ``or`` — semantically
+    identical to a flat ``coalesce`` since it returns the first non-null operand:
+
+        >>> DftlyGrammar.parse_str("$a ?? $b ?? 'UNK'")
+        {'coalesce': [{'coalesce': [{'column': 'a'}, {'column': 'b'}]}, {'literal': 'UNK'}]}
+
+    It binds looser than the boolean operators (matching C#/JS), so ``$x or $y ?? $z`` groups
+    as ``($x or $y) ?? $z``:
+
+        >>> DftlyGrammar.parse_str("$x or $y ?? $z")
+        {'coalesce': [{'or': [{'column': 'x'}, {'column': 'y'}]}, {'column': 'z'}]}
+
+    End-to-end, per-field sentinels in interpolation fall out for free, because an
+    interpolation field is itself a full sub-expression:
+
+        >>> from dftly import Parser
+        >>> df = pl.DataFrame({"a": ["x", None], "b": [None, "y"]})
+        >>> df.select(Parser.expr_to_polars('f"{$a ?? \\'UNK\\'}//{$b ?? \\'UNK\\'}"')).to_series().to_list()
+        ['x//UNK', 'UNK//y']
     """
 
     KEY = "coalesce"

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -3,16 +3,17 @@
 // Precedence (lowest to highest):
 //   1. global_cast   — `... as type` / `... as '%fmt'` / `... @ TIME`
 //   2. conditional    — `... if ... else ...`
-//   3. bool_or        — `or`, `||`
-//   4. bool_and       — `and`, `&&`  (AND binds tighter than OR, as in Python/SQL/C)
-//   5. comparison     — `==`, `!=`, `>`, `<`, `>=`, `<=`
-//   6. additive       — `+`, `-`
-//   7. multiplicative — `*`, `/`
-//   8. exp_expr       — `**` (right-associative)
-//   9. local_cast     — `::type` / `::'%fmt'`
-//  10. unary          — `not`, `!`, unary `+`/`-`
-//  11. postfix        — `[start:stop]` substring shorthand (binds tighter than unary)
-//  12. primary        — literals, columns, function calls, regex, parenthesized expressions
+//   3. coalesce_expr  — `??` null-coalescing (desugars to the `coalesce` node)
+//   4. bool_or        — `or`, `||`
+//   5. bool_and       — `and`, `&&`  (AND binds tighter than OR, as in Python/SQL/C)
+//   6. comparison     — `==`, `!=`, `>`, `<`, `>=`, `<=`
+//   7. additive       — `+`, `-`
+//   8. multiplicative — `*`, `/`
+//   9. exp_expr       — `**` (right-associative)
+//  10. local_cast     — `::type` / `::'%fmt'`
+//  11. unary          — `not`, `!`, unary `+`/`-`
+//  12. postfix        — `[start:stop]` substring shorthand (binds tighter than unary)
+//  13. primary        — literals, columns, function calls, regex, parenthesized expressions
 //
 // Priority annotations (e.g. `.1`, `.2`) on terminals resolve lexer ambiguities:
 // higher priority terminals are preferred when multiple patterns match the same input.
@@ -53,6 +54,7 @@ AND_SYM: "&&"
 OR_SYM: "||"
 NOT_SYM: "!"
 QUESTION: "?"
+COALESCE_OP: "??"
 LBRACK: "["
 RBRACK: "]"
 COLON: ":"
@@ -88,7 +90,17 @@ FROM.2: /from/i
             | conditional
 
 ?conditional: expr IF expr (ELSE expr)?   -> conditional
-            | bool_or
+            | coalesce_expr
+
+// Null-coalescing `a ?? b` — first non-null operand. Pure sugar: `coalesce_op` rewrites
+// this into the existing `coalesce` node's base form (see AGENTS.md form hierarchy), so
+// `$a ?? UNK` and `coalesce($a, UNK)` produce the same tree. Left-associative, so chains
+// like `$a ?? $b ?? UNK` nest as `coalesce(coalesce($a, $b), UNK)` — semantically identical
+// to `coalesce($a, $b, UNK)`, and consistent with how `+`/`or` chain in this grammar.
+// Placed below `if/else` and above `or`/`and` (matching C#/JS, where `??` binds looser than
+// the boolean operators): `$x or $y ?? $z` parses as `($x or $y) ?? $z`.
+?coalesce_expr: coalesce_expr COALESCE_OP bool_or   -> coalesce_op
+              | bool_or
 
 ?bool_or: bool_or (OR_SYM|OR) bool_and   -> binary_expr
         | bool_and

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -15,6 +15,7 @@ from ..nodes import (
     DT_CAST_ACCESSORS,
     NODES,
     Cast,
+    Coalesce,
     Literal,
 )
 
@@ -244,7 +245,7 @@ class DftlyGrammar(Transformer):
         return Discard
 
     IF = ELSE = EXTRACT = GROUP = OF = FROM = IN = CAST = AS = _discard_token
-    FORMAT_PFX = DOLLAR = QUESTION = _discard_token
+    FORMAT_PFX = DOLLAR = QUESTION = COALESCE_OP = _discard_token
     LBRACK = RBRACK = COLON = _discard_token
 
     def NAME(self, val: Token) -> str:
@@ -300,6 +301,14 @@ class DftlyGrammar(Transformer):
         if name in DT_CAST_ACCESSORS:
             return DT_CAST_ACCESSORS[name].from_lark([input])
         return Cast.from_lark([input, Literal.from_lark(output_type)])
+
+    def coalesce_op(self, items: list[Any]) -> dict:
+        # Null-coalescing `left ?? right` is sugar for the existing `coalesce` node. The
+        # ``COALESCE_OP`` token is discarded (see the `_discard_token` assignments above), so
+        # ``items`` is ``[left, right]``. Left-associative chains arrive already nested, e.g.
+        # ``$a ?? $b ?? UNK`` gives ``left = {"coalesce": [$a, $b]}``; we keep that nesting
+        # rather than flattening, matching how `binary_expr` chains `+`/`or`.
+        return Coalesce.from_lark(items)
 
     # Substring shorthand `$col[start:stop]` → Substring(source, start, stop).
     # The four `substring_slice_*` methods return kwargs dicts without a `source`;


### PR DESCRIPTION
## Summary

Adds a `??` null-coalescing infix operator to the string-form grammar. It returns its first non-null operand, giving a concise way to substitute a sentinel for nulls — including per-field inside `f"{...}"` interpolation.

`??` is **pure syntactic sugar** for the existing `coalesce` node: `$a ?? UNK` parses to exactly the same base-form tree as `coalesce($a, UNK)`. It introduces no new node type and honors the form-hierarchy rule in `AGENTS.md` (string form is sugar; every string feature reduces to an existing base form). Because an interpolation field is itself a full sub-expression, per-field sentinels like `f"{$a ?? 'UNK'}"` work with no interpolation-specific code.

```yaml
filled:  "$a ?? 'UNK'"                        # standalone
joined:  "f\"{$a ?? 'UNK'}//{$b ?? 'UNK'}\""  # per-field in interpolation
chained: "$a ?? $b ?? 'UNK'"                   # nests as coalesce(coalesce(a,b),'UNK')
count:   "$n ?? 0"                             # non-string sentinels too
```

## Changes

- **`grammar.lark`**: new terminal `COALESCE_OP: "??"` and a `coalesce_expr` precedence level between `conditional` and `bool_or` (left-associative). Placement matches C#/JS — `??` binds looser than the boolean operators and tighter than a trailing `if/else`, so `$x or $y ?? $z` groups as `($x or $y) ?? $z`.
- **`str_form/parser.py`**: `coalesce_op` transformer method rewrites `left ?? right` into the existing `coalesce` node's base form (mirrors how `cast_expr` wraps tokens); `COALESCE_OP` token discarded.
- **`nodes/arithmetic.py`**: doctests on the `Coalesce` node showing `$a ?? UNK` is identical to `coalesce($a, UNK)`, plus chaining, precedence, and interpolation.
- **`README.md`**: new "Null-coalescing with `??`" subsection (doctested).

## Design fit

Follows `AGENTS.md`: no new node, `coalesce_op` returns a dict keyed by the existing `coalesce` node. Chains nest left-associatively (`coalesce(coalesce($a,$b),UNK)`) — semantically identical to a flat `coalesce` since it returns the first non-null operand, and consistent with how `+`/`or` chain in this grammar.

## Testing

- Full suite green (`uv run pytest`): **74 passed**.
- Verified single-`?` non-strict strptime (`$dod::?"%fmt"`) is unaffected — longest match keeps `??` from colliding with `?`.
- `ruff check` / `ruff format` clean; all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)