### PR TITLE
Add `f"..." fill X` bulk null-fill for string interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,40 @@ Slice step (`[i:j:k]`) and single-index subscription (`[i]`) are intentionally u
 polars' `str.slice` has no step, and single-index is expressible as `substring(expr, i, i+1)`.
 Both produce a clear parse error pointing at the supported forms.
 
+### Bulk null-filling in string interpolation
+
+In an `f"..."` interpolation, a single null field nulls the **entire** formatted string — so
+one missing column blanks the whole output. The `fill` suffix guards against this: `f"..." fill X`
+substitutes the sentinel `X` for null in **every** field of that interpolation at once.
+
+It is pure sugar — `f"{$a}//{$b}" fill 'UNK'` is exactly equivalent to wrapping each field in
+[`coalesce`](#detailed-documentation) by hand (`f"{coalesce($a, 'UNK')}//{coalesce($b, 'UNK')}"`),
+and desugars to a plain `string_interpolate` node with no new machinery:
+
+```python
+>>> null_df = pl.DataFrame({"first": ["Ann", None], "last": [None, "Wu"]})
+>>> fill_ops = {
+...     "plain": 'f"{$first} {$last}"',
+...     "filled": '''f"{$first} {$last}" fill '?' ''',
+... }
+>>> null_df.select(**Parser.to_polars(fill_ops))
+shape: (2, 2)
+┌───────┬────────┐
+│ plain ┆ filled │
+│ ---   ┆ ---    │
+│ str   ┆ str    │
+╞═══════╪════════╡
+│ null  ┆ Ann ?  │
+│ null  ┆ ? Wu   │
+└───────┴────────┘
+
+```
+
+The fill operand can be any literal, column, bare word, or parenthesized expression (use parens
+for a compound fill, e.g. `fill ($a + $b)`). For a *per-field* sentinel — different fallbacks for
+different columns — write the `coalesce` explicitly inside each `{...}` instead, since an
+interpolation field is itself a full expression.
+
 You can also add literal columns:
 
 ```python

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -85,6 +85,36 @@ class StringInterpolate(ArgsOnlyFn):
         Traceback (most recent call last):
             ...
         ValueError: When using `from_lark` with a dictionary, the dictionary must resolve to a Literal node.
+
+    A null interpolated field nulls the *entire* formatted string, which is rarely what you want.
+    The ``f"..." fill X`` string-form suffix guards against this: it is sugar that wraps every
+    field in ``coalesce(field, X)``, so one sentinel substitutes for nulls across the whole
+    f-string. It desugars to a plain ``string_interpolate`` built from existing nodes — no new
+    node type — and so is exactly equivalent to writing the ``coalesce`` on each field by hand:
+
+        >>> from dftly.str_form.parser import DftlyGrammar
+        >>> DftlyGrammar.parse_str('f"{$a}//{$b}" fill \\'UNK\\'')
+        {'string_interpolate': [{'literal': '{}//{}'},
+                                {'coalesce': ['$a', {'literal': 'UNK'}]},
+                                {'coalesce': ['$b', {'literal': 'UNK'}]}]}
+
+    Without ``fill`` a single null propagates to the whole row; with it, each field falls back to
+    the sentinel:
+
+        >>> from dftly import Parser
+        >>> df = pl.DataFrame({"a": ["x", None], "b": [None, "y"]})
+        >>> df.select(Parser.expr_to_polars('f"{$a}//{$b}"')).to_series().to_list()
+        [None, None]
+        >>> df.select(Parser.expr_to_polars('f"{$a}//{$b}" fill \\'UNK\\'')).to_series().to_list()
+        ['x//UNK', 'UNK//y']
+
+    The fill operand is any ``primary`` (literal, column, bare word, or a parenthesized
+    expression); use parens for a compound fill. A pattern with no fields to fill is an error:
+
+        >>> DftlyGrammar.parse_str('f"no fields" fill \\'UNK\\'')
+        Traceback (most recent call last):
+            ...
+        lark.exceptions.VisitError: ...`fill` requires an interpolation with at least one field...
     """
 
     KEY = "string_interpolate"

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -75,6 +75,7 @@ EXTRACT.2: /extract/i
 GROUP.2: /group/i
 OF.2: /of/i
 FROM.2: /from/i
+FILL.2: /fill/i
 
 ?start: expr
 
@@ -161,6 +162,13 @@ FROM.2: /from/i
 ?primary: regex
         | call_expr
         | (DOLLAR)NAME -> column
+        // Bulk null-fill: `f"..." fill X` wraps every interpolation field in `coalesce(field, X)`,
+        // so one sentinel applies to the whole f-string. Pure sugar over `string_interpolate` +
+        // `coalesce` (see `string_interpolate_fill` in parser.py) — no new node type. Must precede
+        // the plain interpolation alternative so LALR shifts `FILL` instead of reducing early. The
+        // fill operand is a `primary` (literal, column, bare word, or parenthesized expression),
+        // which keeps it unambiguous; use parens for a compound fill (`fill ($a + $b)`).
+        | (FORMAT_PFX)STRING FILL primary -> string_interpolate_fill
         | (FORMAT_PFX)STRING -> string_interpolate
         | time_literal
         | DATE

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -15,7 +15,9 @@ from ..nodes import (
     DT_CAST_ACCESSORS,
     NODES,
     Cast,
+    Coalesce,
     Literal,
+    StringInterpolate,
 )
 
 
@@ -244,7 +246,7 @@ class DftlyGrammar(Transformer):
         return Discard
 
     IF = ELSE = EXTRACT = GROUP = OF = FROM = IN = CAST = AS = _discard_token
-    FORMAT_PFX = DOLLAR = QUESTION = _discard_token
+    FORMAT_PFX = DOLLAR = QUESTION = FILL = _discard_token
     LBRACK = RBRACK = COLON = _discard_token
 
     def NAME(self, val: Token) -> str:
@@ -293,6 +295,25 @@ class DftlyGrammar(Transformer):
         result = Strptime.from_lark(items)
         result[Strptime.KEY]["strict"] = Literal.from_lark(False)
         return result
+
+    def string_interpolate_fill(self, items: list[Any]) -> dict:
+        # `f"..." fill X` is sugar for a plain interpolation whose every field is wrapped in
+        # `coalesce(field, X)`, so one sentinel guards the whole f-string against nulls. The
+        # ``FORMAT_PFX`` and ``FILL`` tokens are discarded, so ``items`` is ``[pattern, fill]``.
+        # We reuse ``StringInterpolate.from_lark`` to split the pattern into its normalized
+        # ``"{}"`` form plus the field expressions, then re-wrap each field. The output is a
+        # ``string_interpolate`` base form built only from existing nodes (no new node type),
+        # honoring the form hierarchy in AGENTS.md.
+        pattern, fill = items
+        base = StringInterpolate.from_lark([pattern])[StringInterpolate.KEY]
+        pattern_lit, fields = base[0], base[1:]
+        if not fields:
+            raise ValueError(
+                "`fill` requires an interpolation with at least one field to fill; "
+                f"the pattern has none: {pattern_lit}"
+            )
+        wrapped = [Coalesce.from_lark([field, fill]) for field in fields]
+        return {StringInterpolate.KEY: [pattern_lit] + wrapped}
 
     def cast_expr(self, items: list[Any]) -> dict:
         input, output_type = items


### PR DESCRIPTION
## Summary

Adds a `fill` suffix to f-string interpolation that substitutes a single sentinel for null across **every** field at once. This is the "bulk" companion to per-field null handling.

**Motivation:** in an `f"..."` interpolation, a single null field nulls the *entire* formatted string — one missing column blanks the whole output. `f"..." fill X` guards against that in one place:

```yaml
name: "f\"{$first} {$last}\" fill 'UNK'"
```

## Design

Pure syntactic sugar over the existing `string_interpolate` + `coalesce` nodes — **no new node type**. `f"{$a}//{$b}" fill 'UNK'` desugars to a plain interpolation whose every field is wrapped in `coalesce(field, 'UNK')`, i.e. exactly equivalent to writing the coalesce on each field by hand:

```
f"{coalesce($a, 'UNK')}//{coalesce($b, 'UNK')}"
```

This follows the form-hierarchy rule in `AGENTS.md` ("composing existing primitives is always preferable to grammar-level magic"; every string feature reduces to an existing base form).

## Changes

- **`grammar.lark`**: new keyword terminal `FILL.2: /fill/i` and a `primary` alternative `(FORMAT_PFX)STRING FILL primary -> string_interpolate_fill`, placed before the plain interpolation alternative so LALR shifts `FILL`. The contextual lexer keeps `fill` usable as a column (`$fill`) and bare word elsewhere — no new global reserved word, and no LALR conflict.
- **`str_form/parser.py`**: `string_interpolate_fill` transformer reuses `StringInterpolate.from_lark` to split the pattern, then wraps each field in `coalesce(field, fill)`. A pattern with no fields to fill raises a clear error.
- **`nodes/str.py`**: doctests on `StringInterpolate` demonstrating the desugaring, the null-propagation motivation, and the no-fields error.
- **`README.md`**: new "Bulk null-filling in string interpolation" subsection (doctested).

The fill operand is any `primary` (literal, column, bare word, or parenthesized expression); use parens for a compound fill (`fill ($a + $b)`). Per-field sentinels remain available by writing `coalesce` inside `{...}`, since an interpolation field is itself a full expression.

## Testing

- Full suite green (`uv run pytest`): **74 passed**.
- Verified `pl.format` nulls the whole output on a null field (the motivation), and `fill` restores per-field fallback.
- Confirmed no LALR conflict and that `$fill`/bare `fill` still parse as column/bare word.
- `ruff check` / `ruff format` clean; all pre-commit hooks pass.

## Relationship to #76

Independent of #76 (the `??` operator) and branched from `main`. The two compose: `??` gives *per-field* coalescing sugar, while `fill` applies *one* sentinel to a whole interpolation. Neither depends on the other; they can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)