### PR TITLE
Lower `Add` to binary `+` instead of `pl.sum_horizontal`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,11 @@ pre-commit run --all-files
 - Column references use `$` prefix in string form (`$col_name`).
 - `from_lark` must return `{cls.KEY: args_or_kwargs}` -- never a different node's key.
 - `polars_expr` is a property, not a method.
-- `pl_fn` is a `ClassVar` on `ArgsOnlyFn` subclasses -- don't use `@classmethod` for it.
+- `pl_fn` on `ArgsOnlyFn` subclasses is normally a `ClassVar` holding a bare polars callable
+    (`pl_fn = pl.any_horizontal`). Use a `@classmethod` only when the node folds its arguments and
+    has no single polars equivalent -- `Add` and `Multiply` both do this. Either form works:
+    `_ArgsFn.polars_expr` calls `self.__class__.pl_fn(*args)`, which resolves correctly for a
+    plain function and for a classmethod alike.
 - Keyword-only nodes validate via `REQUIRED_KWARGS` and `OPTIONAL_KWARGS` sets.
 - Custom transformer methods in `DftlyGrammar` (like `cast_expr`, `strptime_nonstrict`) are
     acceptable when the grammar needs to wrap tokens into the base form, but they must still

--- a/src/dftly/nodes/arithmetic.py
+++ b/src/dftly/nodes/arithmetic.py
@@ -203,17 +203,6 @@ class Or(ArgsOnlyFn):
 class Add(ArgsOnlyFn):
     """This non-terminal node represents the addition of multiple expressions.
 
-    Compiles to a left fold over polars' binary ``+`` (like :class:`Multiply`), *not* to
-    ``pl.sum_horizontal``. That distinction matters in two ways, both of which make ``+`` behave
-    like the other arithmetic operators rather than like an aggregation:
-
-    1. Nulls propagate, rather than being skipped as if they were zero.
-    2. Operand dtypes are resolved by polars' binary-op rules rather than being cast to a common
-       supertype, so mixed-type arithmetic such as ``Datetime + Duration`` dispatches to polars'
-       native temporal arithmetic.
-
-    If you want null-skipping addition, use an explicit :class:`Coalesce` on the operands.
-
     Example:
         >>> from dftly.nodes import Literal
         >>> pl.select(Add(Literal(1), Literal(2), Literal(3)).polars_expr).item()

--- a/src/dftly/nodes/arithmetic.py
+++ b/src/dftly/nodes/arithmetic.py
@@ -203,17 +203,59 @@ class Or(ArgsOnlyFn):
 class Add(ArgsOnlyFn):
     """This non-terminal node represents the addition of multiple expressions.
 
+    Compiles to a left fold over polars' binary ``+`` (like :class:`Multiply`), *not* to
+    ``pl.sum_horizontal``. That distinction matters in two ways, both of which make ``+`` behave
+    like the other arithmetic operators rather than like an aggregation:
+
+    1. Nulls propagate, rather than being skipped as if they were zero.
+    2. Operand dtypes are resolved by polars' binary-op rules rather than being cast to a common
+       supertype, so mixed-type arithmetic such as ``Datetime + Duration`` dispatches to polars'
+       native temporal arithmetic.
+
+    If you want null-skipping addition, use an explicit :class:`Coalesce` on the operands.
+
     Example:
         >>> from dftly.nodes import Literal
         >>> pl.select(Add(Literal(1), Literal(2), Literal(3)).polars_expr).item()
         6
         >>> pl.select(Add(Literal("hello "), Literal("world")).polars_expr).item()
         'hello world'
+
+    Nulls propagate, matching :class:`Subtract`, :class:`Multiply`, and :class:`Divide`:
+
+        >>> df = pl.DataFrame({"a": [1, None], "b": [2, 2]})
+        >>> from dftly.nodes import Column
+        >>> df.select(Add(Column("a"), Column("b")).polars_expr.alias("v"))["v"].to_list()
+        [3, None]
+
+    A ``Duration`` can be added to a ``Datetime`` to shift the timestamp, which is the natural
+    shape for offset-time data (an anchor timestamp plus an offset in some unit):
+
+        >>> from dftly.nodes import Cast, Strptime
+        >>> ts = Strptime(format=Literal("%Y-%m-%d %H:%M:%S"), source=Literal("2014-12-31 13:45:00"))
+        >>> offset = Cast(Literal(90), Literal("minutes"))
+        >>> pl.select(Add(ts, offset).polars_expr).item()
+        datetime.datetime(2014, 12, 31, 15, 15)
+
+    At least one argument is required:
+
+        >>> Add().polars_expr
+        Traceback (most recent call last):
+            ...
+        ValueError: add requires at least one argument; got 0
     """
 
     KEY = "add"
     SYM = "+"
-    pl_fn = pl.sum_horizontal
+
+    @classmethod
+    def pl_fn(cls, *args: pl.Expr) -> pl.Expr:
+        if not args:
+            raise ValueError(f"{cls.KEY} requires at least one argument; got 0")
+        result = args[0]
+        for expr in args[1:]:
+            result = result + expr
+        return result
 
 
 class Subtract(BinaryOp):


### PR DESCRIPTION
Closes #80

`Add.pl_fn` was `pl.sum_horizontal` while every other arithmetic node lowers to a binary polars operator. That asymmetry caused two distinct problems, both fixed here by folding over binary `+` (the shape `Multiply` already uses).

### 1. `+` did not propagate nulls

`sum_horizontal` skips nulls, so a missing operand was silently treated as zero:

```python
df = pl.DataFrame({"a": [1, None], "b": [2, 2]})
df.select(**Parser.to_polars({"v": "$a + $b"}))   # before: [3, 2]     after: [3, null]
df.select(**Parser.to_polars({"v": "$a - $b"}))   #         [-1, null] (already correct)
```

A missing measurement becoming `0` rather than staying missing is a quiet data-corruption path, and it was inconsistent with `-`, `*`, and `/`.

### 2. `Datetime + Duration` was unrepresentable

`sum_horizontal` casts operands to a common supertype, so adding a `Duration` to a `Datetime` raised instead of shifting the timestamp. This is version-dependent — it passes on polars 1.33.1 (what the lockfile pins) and fails on 1.43.1:

```
InvalidOperationError: casting from Duration('μs') to Datetime('μs') not supported
```

Notably, **this broke the README's own documented example** on newer polars. On `main` under `polars==1.43.1`:

```
FAILED README.md::README.md          <- ($col3 as "%Y-%m-%d") + $col1::days
FAILED src/dftly/nodes/str.py::dftly.nodes.str.StringInterpolate
2 failed, 72 passed
```

With this change the README example passes again (1 failed, 73 passed). The remaining `StringInterpolate` failure is a pre-existing, unrelated polars output-column-naming change — see the note below.

Downstream, this asymmetry forced offset-time configs to be written backwards as `$anchor - (-$offset)::minutes`, which needs a paragraph of comment to explain it isn't a typo. `$anchor + $offset::minutes` now works.

### Changes

- `Add.pl_fn` becomes a classmethod folding over `+`, mirroring `Multiply`.
- Zero-argument `add` now raises a clear `ValueError` instead of a polars `ComputeError` about empty folds.
- Docstring documents the null-propagation and `Datetime + Duration` semantics, with regression doctests for both, and points at `Coalesce` for anyone who actually wants null-skipping addition.

### Testing

`uv run pytest` → 74 passed on the pinned polars 1.33.1.

### Out of scope (separate issue)

Under `polars==1.43.1` the `StringInterpolate` doctest fails because polars now names the output column after the first referenced column rather than `literal`. That is pre-existing on `main` and unrelated to this change. `pyproject.toml` declares `polars>=1.33` with no upper bound, so this will hit users on current polars — probably worth its own issue, and CI may want to test against the latest polars as well as the locked one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)