### PR TITLE
Extend `::?` to type casts for non-strict conversion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ String expression          Dict/YAML input
         - `Column` -- column references (`$col_name`)
     - `Nonterminal` -- nodes whose args must be other `NodeBase` instances
         - `ArgsOnlyFn` -- variadic positional args (Add, Min, Max, Mean, Coalesce, Hash)
-        - `KwargsOnlyFn` -- keyword args only (Conditional, Strptime, RegexExtract, RegexMatch)
+        - `KwargsOnlyFn` -- keyword args only (Conditional, Strptime, RegexExtract, RegexMatch, Cast)
         - `BinaryOp` -- exactly 2 positional args (Subtract, Divide, comparisons, SetTime)
         - `UnaryOp` -- exactly 1 positional arg (Not, Negate)
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,48 @@ Every datetime/duration accessor also exists as a function-call form — `dt_hou
 `dt_total_seconds($delta)`, etc. — for use in programmatic construction or when the cast
 form doesn't compose cleanly. The two are always equivalent.
 
+### Non-strict conversion with `::?`
+
+Real-world source columns are often "mostly" the type they claim to be — a `VARCHAR` dose column
+holding `"25"` alongside `"1000 MG"`, or a date column with a few unparsable entries. Prefixing
+the cast target with `?` makes the conversion non-strict: values that cannot be converted become
+null instead of raising. This works for both type casts and strptime formats, and means the same
+thing in both (it sets Polars' `strict=False`):
+
+```python
+>>> messy = pl.DataFrame({
+...     "dose": ["25", "1000 MG", "1.5E-3", ""],
+...     "dod": ["2020-06-20", "not a date", "2021-01-05", "2019-12-31"],
+... })
+>>> ops = r"""
+... numeric_value: '$dose::?float64'
+... death_date: '$dod::?"%Y-%m-%d"'
+... """
+>>> messy.select(**Parser.to_polars(ops))
+shape: (4, 2)
+┌───────────────┬────────────┐
+│ numeric_value ┆ death_date │
+│ ---           ┆ ---        │
+│ f64           ┆ date       │
+╞═══════════════╪════════════╡
+│ 25.0          ┆ 2020-06-20 │
+│ null          ┆ null       │
+│ 0.0015        ┆ 2021-01-05 │
+│ null          ┆ 2019-12-31 │
+└───────────────┴────────────┘
+
+```
+
+Without the `?`, both forms raise on the first unconvertible value, which is the right default —
+`?` is how you opt in to dropping data. Because it delegates to Polars' own parser, `::?float64`
+accepts everything Polars accepts (`1.5E-3`, `+5`, `inf`, `nan`) rather than whatever subset a
+hand-written regex guard happens to cover.
+
+The `?` prefix applies only to real dtype casts. The duration/date unit casts (`::minutes`,
+`::year`) build values with `pl.duration()`/`pl.date()`, and the datetime accessors
+(`::hour_of_day`) extract a component — none of these have a strictness to relax, so `::?minutes`
+and `::?hour_of_day` are errors rather than silent no-ops.
+
 ### Position-based string operations
 
 `len_chars($col)` returns the Unicode character count of a string column, and

--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -114,6 +114,11 @@ __binary_ops = [node for node in __nodes if issubclass(node, BinaryOp)]
 __binary_ops.extend(
     [Add, Multiply, And, Or]
 )  # Additional n-ary ops that can be used as binary ops
+# ``Cast`` carries SYM = "::" but is a KwargsOnlyFn (its canonical base form is
+# ``{source, type, strict}``), so it is registered here explicitly rather than being picked up by
+# the BinaryOp scan above. Its ``from_lark`` still accepts the ``[left, right]`` pair that the
+# binary-op dispatch would hand it.
+__binary_ops.append(Cast)
 
 BINARY_OPS = NodeBase.unique_dict_by_prop(__binary_ops, "SYM")
 

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -743,7 +743,8 @@ class Substring(KwargsOnlyFn):
         >>> DftlyGrammar.parse_str("$code[10:30:45]")
         Traceback (most recent call last):
             ...
-        lark.exceptions.VisitError: ... Slice shorthand does not support step ...
+        ValueError: Failed to parse expression '$code[10:30:45]': Slice shorthand does not support
+        step (got '10:30:45'); use the substring() function form.
 
     End-to-end: the MIMIC ICD dot-insertion pattern (``add_dot($code, 3)``) combines
     :class:`LenChars` and :class:`Substring` to produce a declarative equivalent of the

--- a/src/dftly/nodes/types.py
+++ b/src/dftly/nodes/types.py
@@ -1,7 +1,7 @@
 """Nodes relating to type casting."""
 
-from typing import Callable
-from .base import BinaryOp, NodeBase
+from typing import Any, Callable
+from .base import KwargsOnlyFn, NodeBase
 import polars as pl
 
 NUMERIC_TYPES: dict[str, pl.DataType] = {
@@ -73,17 +73,34 @@ TYPES.update({k: pl.Duration for k in IMPLICIT_DURATION_TYPES})
 TYPES.update({k: pl.Date for k in IMPLICIT_DATE_TYPES})
 
 
-class Cast(BinaryOp):
-    """This non-terminal node casts the left expression to the type specified by the right expression.
+class Cast(KwargsOnlyFn):
+    """This non-terminal node casts a source expression to the type named by its ``type`` argument.
 
-    The right node of this expression must evaluate to a string literal outside of any specific polars context
-    that is one of the supported types defined in the `TYPES` dictionary. Most of the supported types are
-    standard polars types, but some common aliases are also supported (e.g. "int" for "Int32", "float" for
-    "Float32", and "str" for "Utf8").
+    The ``type`` node must evaluate to a string literal outside of any specific polars context that is one of
+    the supported types defined in the `TYPES` dictionary. Most of the supported types are standard polars
+    types, but some common aliases are also supported (e.g. "int" for "Int32", "float" for "Float32", and
+    "str" for "Utf8").
 
     In addition, some custom types are added which resolve to standard polars types through a more complex
     mapping; in particular, duration units ("seconds", "minutes", "hours", "days", "weeks", "months", "years")
     convert numeric values into durations, and "year" converts an integer into a date at the start of that year.
+
+    The optional ``strict`` argument controls what happens to values that cannot be converted. It mirrors
+    :class:`~dftly.nodes.str.Strptime`'s ``strict`` argument, and for the same reason -- both lower onto a
+    polars ``strict=`` parameter meaning "on failure, produce null instead of raising":
+
+    ==============================  ===============================  ==================
+    dftly                           polars                           ``strict=False``
+    ==============================  ===============================  ==================
+    ``$x::?"%Y-%m-%d"``             ``.str.strptime(..., strict=)``   unparsable -> null
+    ``$x::?float64``                ``.cast(..., strict=)``           unconvertible -> null
+    ==============================  ===============================  ==================
+
+    ``strict`` defaults to ``True`` (raise), matching polars.
+
+    For convenience, this node also accepts its two required arguments positionally -- ``Cast(source, type)``
+    and the base form ``{"cast": [source, type]}`` are sugar for the canonical keyword form. Positional form
+    cannot carry ``strict``; use the keyword form for that.
 
     Example:
         >>> from dftly.nodes import Literal
@@ -106,6 +123,32 @@ class Cast(BinaryOp):
         >>> pl.select(Cast(Literal(42), Literal("str")).polars_expr).item()
         '42'
 
+    The positional form above is sugar for the canonical keyword form, and normalizes to it:
+
+        >>> Cast(Literal("3"), Literal("int"))
+        Cast(source=Literal('3'), type=Literal('int'))
+        >>> Cast(source=Literal("3"), type=Literal("int"))
+        Cast(source=Literal('3'), type=Literal('int'))
+
+    By default a cast is strict, so a value that cannot be converted raises:
+
+        >>> pl.select(Cast(Literal("1000 MG"), Literal("float64")).polars_expr)
+        Traceback (most recent call last):
+            ...
+        polars.exceptions.InvalidOperationError: conversion from `str` to `f64` failed ...
+
+    Passing ``strict=Literal(False)`` nulls unconvertible values instead. This is the natural
+    counterpart to non-strict strptime, and is what ``$x::?float64`` parses to:
+
+        >>> lenient = Cast(source=Literal("1000 MG"), type=Literal("float64"), strict=Literal(False))
+        >>> print(pl.select(lenient.polars_expr).item())
+        None
+        >>> df = pl.DataFrame({"dose": ["25", "1000 MG", "", "1.5E-3", "+5", "inf"]})
+        >>> from dftly.nodes import Column
+        >>> node = Cast(source=Column("dose"), type=Literal("float64"), strict=Literal(False))
+        >>> df.select(node.polars_expr)["dose"].to_list()
+        [25.0, None, None, 0.0015, 5.0, inf]
+
     Unsupported types raise an error:
 
         >>> Cast(Literal("3"), Literal("unsupported_type"))
@@ -115,11 +158,21 @@ class Cast(BinaryOp):
 
     A non-evaluatable type argument raises an error:
 
-        >>> from dftly.nodes import Column
         >>> Cast(Literal("3"), Column("x"))
         Traceback (most recent call last):
             ...
-        ValueError: The right node of a Cast operation must evaluate to a string literal.
+        ValueError: The type argument of a Cast operation must evaluate to a string literal.
+
+    Positional form requires exactly two arguments, and cannot be mixed with the keyword form:
+
+        >>> Cast(Literal("3"))
+        Traceback (most recent call last):
+            ...
+        ValueError: cast requires exactly two positional arguments (source, type); got 1
+        >>> Cast(Literal("3"), Literal("int"), source=Literal("4"))
+        Traceback (most recent call last):
+            ...
+        ValueError: cast cannot mix positional and keyword arguments; got positional args with {'source'}
 
     This class can also be used to convert numeric types into duration types by specifying their unit:
 
@@ -146,28 +199,97 @@ class Cast(BinaryOp):
 
         >>> pl.select(Cast(Literal(2023), Literal("year")).polars_expr).item()
         datetime.date(2023, 1, 1)
+
+    Those implicit units do not lower to a polars ``.cast()`` -- they build a value via
+    ``pl.duration()`` / ``pl.date()``, which have no ``strict`` parameter to forward. Rather than
+    silently ignoring the flag, asking for a non-strict conversion to one of them is an error:
+
+        >>> Cast(source=Literal(3), type=Literal("minutes"), strict=Literal(False))
+        Traceback (most recent call last):
+            ...
+        ValueError: Non-strict casting is not supported for unit 'minutes'; `strict` applies only to
+        dtype casts...
+
+    A non-boolean ``strict`` value raises an error:
+
+        >>> Cast(source=Literal("3"), type=Literal("int"), strict=Literal("yes"))
+        Traceback (most recent call last):
+            ...
+        ValueError: The strict argument must be a boolean, ...
     """
 
     KEY = "cast"
     SYM = "::"
+    REQUIRED_KWARGS = {"source", "type"}
+    OPTIONAL_KWARGS = {"strict"}
 
     def __post_init__(self):
+        # `Cast(source, type)` is positional sugar for the canonical keyword form; normalize it
+        # before the KwargsOnlyFn validators run (they reject positional args outright).
+        if self.args:
+            if self.kwargs:
+                raise ValueError(
+                    f"{self.KEY} cannot mix positional and keyword arguments; got positional args "
+                    f"with {set(self.kwargs)}"
+                )
+            if len(self.args) != 2:
+                raise ValueError(
+                    f"{self.KEY} requires exactly two positional arguments (source, type); "
+                    f"got {len(self.args)}"
+                )
+            source, output_type = self.args
+            self.args = ()
+            self.kwargs = {"source": source, "type": output_type}
+
         super().__post_init__()
+
         if self.output_type not in TYPES:
             raise ValueError(f"Unsupported type: {self.output_type}")
 
+        if not self.strict and not self._lowers_to_cast:
+            raise ValueError(
+                f"Non-strict casting is not supported for unit {self.output_type!r}; `strict` "
+                "applies only to dtype casts. This unit is built with pl.duration()/pl.date(), "
+                "which have no `strict` parameter to forward."
+            )
+
     @property
     def input(self) -> NodeBase:
-        return self.args[0]
+        return self.kwargs["source"]
 
     @property
     def output_type(self) -> str:
         try:
-            return pl.select(self.args[1].polars_expr).item()
+            return pl.select(self.kwargs["type"].polars_expr).item()
         except Exception as e:
             raise ValueError(
-                "The right node of a Cast operation must evaluate to a string literal."
+                "The type argument of a Cast operation must evaluate to a string literal."
             ) from e
+
+    @property
+    def _lowers_to_cast(self) -> bool:
+        """Whether this node compiles to a real ``.cast()`` (rather than an implicit unit builder)."""
+        return (
+            self.output_type not in IMPLICIT_DURATION_TYPES
+            and self.output_type not in IMPLICIT_DATE_TYPES
+        )
+
+    @property
+    def strict(self) -> bool:
+        strict_node = self.kwargs.get("strict", None)
+        if strict_node is None:
+            return True  # default: strict=True, matching polars
+        if not isinstance(strict_node, NodeBase):
+            raise ValueError(
+                "The strict argument must be a NodeBase instance that evaluates to a boolean."
+            )
+        try:
+            val = pl.select(strict_node.polars_expr).item()
+        except Exception as e:
+            raise ValueError("The strict argument must evaluate to a boolean.") from e
+        if not isinstance(val, bool):
+            raise ValueError(f"The strict argument must be a boolean, got {type(val)}")
+        return val
 
     @property
     def polars_expr(self) -> pl.Expr:
@@ -176,4 +298,17 @@ class Cast(BinaryOp):
         elif self.output_type in IMPLICIT_DATE_TYPES:
             return IMPLICIT_DATE_TYPES[self.output_type](self.input.polars_expr)
         else:
-            return self.input.polars_expr.cast(TYPES[self.output_type])
+            return self.input.polars_expr.cast(
+                TYPES[self.output_type], strict=self.strict
+            )
+
+    @classmethod
+    def from_lark(cls, items: list[Any]) -> dict[str, Any]:
+        """Build the canonical keyword base form from the grammar's ``[source, type]`` pair.
+
+        Examples:
+            >>> Cast.from_lark([{"column": "dose"}, {"literal": "float64"}])
+            {'cast': {'source': {'column': 'dose'}, 'type': {'literal': 'float64'}}}
+        """
+        source, output_type = items
+        return {cls.KEY: {"source": source, "type": output_type}}

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -1,7 +1,7 @@
 // Dftly expression grammar (LALR(1))
 //
 // Precedence (lowest to highest):
-//   1. global_cast   — `... as type` / `... as '%fmt'` / `... @ TIME`
+//   1. global_cast   — `... as type` / `... as '%fmt'` / `... @ TIME` (`?` prefix = non-strict)
 //   2. conditional    — `... if ... else ...`
 //   3. coalesce_expr  — `??` null-coalescing (desugars to the `coalesce` node)
 //   4. bool_or        — `or`, `||`
@@ -10,7 +10,7 @@
 //   7. additive       — `+`, `-`
 //   8. multiplicative — `*`, `/`
 //   9. exp_expr       — `**` (right-associative)
-//  10. local_cast     — `::type` / `::'%fmt'`
+//  10. local_cast     — `::type` / `::'%fmt'` (`?` prefix = non-strict, e.g. `::?float64`)
 //  11. unary          — `not`, `!`, unary `+`/`-`
 //  12. postfix        — `[start:stop]` substring shorthand (binds tighter than unary)
 //  13. primary        — literals, columns, function calls, regex, parenthesized expressions
@@ -84,6 +84,7 @@ FROM.2: /from/i
 
 // Lowest precedence: global cast with `as`/`@` binds last
 ?global_cast: conditional AS NAME   -> cast_expr
+            | conditional AS QUESTION NAME -> cast_expr_nonstrict
             | conditional AS STRING -> strptime
             | conditional AS QUESTION STRING -> strptime_nonstrict
             | conditional AT time_literal   -> binary_expr
@@ -131,6 +132,7 @@ FROM.2: /from/i
 
 // Higher precedence: local cast with `::` binds tighter than arithmetic
 ?local_cast: unary CAST NAME   -> cast_expr
+           | unary CAST QUESTION NAME -> cast_expr_nonstrict
            | unary CAST STRING -> strptime
            | unary CAST QUESTION STRING -> strptime_nonstrict
            | unary

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -7,6 +7,7 @@ from dateutil import parser as dt_parser
 
 from importlib.resources import files
 from lark import Lark, Token, Transformer
+from lark.exceptions import VisitError
 from lark.visitors import Discard
 
 from ..nodes import (
@@ -102,12 +103,34 @@ class DftlyGrammar(Transformer):
     `::` having higher precedence than arithmetic operations, and `as` having lower precedence.
 
         >>> DftlyGrammar.parse_str("4 + '3'::int")
-        {'add': [{'literal': 4}, {'cast': [{'literal': '3'}, {'literal': 'int'}]}]}
+        {'add': [{'literal': 4},
+                 {'cast': {'source': {'literal': '3'}, 'type': {'literal': 'int'}}}]}
         >>> DftlyGrammar.parse_str("'2023-' + '01-' + '01' as date")
-        {'cast': [{'add': [{'add': [{'literal': '2023-'},
-                                    {'literal': '01-'}]},
-                           {'literal': '01'}]},
-                  {'literal': 'date'}]}
+        {'cast': {'source': {'add': [{'add': [{'literal': '2023-'},
+                                              {'literal': '01-'}]},
+                                     {'literal': '01'}]},
+                  'type': {'literal': 'date'}}}
+
+    The ``?`` prefix marks a cast non-strict, exactly as it does for strptime formats: values that
+    cannot be converted become null instead of raising. Both spellings support it:
+
+        >>> DftlyGrammar.parse_str("$dosage::?float64")
+        {'cast': {'source': {'column': 'dosage'},
+                  'type': {'literal': 'float64'},
+                  'strict': {'literal': False}}}
+        >>> DftlyGrammar.parse_str("$dosage as ?float64")
+        {'cast': {'source': {'column': 'dosage'},
+                  'type': {'literal': 'float64'},
+                  'strict': {'literal': False}}}
+
+    The datetime accessors reachable through cast syntax extract a component rather than convert a
+    value, so there is no strictness to relax and ``?`` is rejected rather than quietly ignored:
+
+        >>> DftlyGrammar.parse_str("$ts::?hour_of_day")
+        Traceback (most recent call last):
+            ...
+        ValueError: Failed to parse expression '$ts::?hour_of_day': Non-strict casting (`::?`) is
+        not supported for accessor 'hour_of_day'; `strict` applies only to dtype casts.
 
     Unary operations are supported:
 
@@ -195,13 +218,27 @@ class DftlyGrammar(Transformer):
             Traceback (most recent call last):
                 ...
             ValueError: Failed to parse expression '???': ...
+
+        Errors raised inside transformer methods are reported the same way. Lark wraps those in a
+        ``VisitError`` whose message buries the actionable part under a rule name and a chained
+        traceback, so the underlying error is unwrapped here:
+
+            >>> DftlyGrammar.parse_str("nonexistent_fn($a)")
+            Traceback (most recent call last):
+                ...
+            ValueError: Failed to parse expression 'nonexistent_fn($a)': Unsupported function: ...
         """
         try:
             tree = GRAMMAR.parse(s)
         except Exception as e:
             raise ValueError(f"Failed to parse expression {s!r}: {e}") from e
 
-        return cls().transform(tree)
+        try:
+            return cls().transform(tree)
+        except VisitError as e:
+            raise ValueError(
+                f"Failed to parse expression {s!r}: {e.orig_exc}"
+            ) from e.orig_exc
 
     # TIME intentionally omitted: parsed at the rule level via ``time_literal`` so the
     # raw Token remains accessible to the substring slice-spec handler, which needs to
@@ -301,6 +338,24 @@ class DftlyGrammar(Transformer):
         if name in DT_CAST_ACCESSORS:
             return DT_CAST_ACCESSORS[name].from_lark([input])
         return Cast.from_lark([input, Literal.from_lark(output_type)])
+
+    def cast_expr_nonstrict(self, items: list[Any]) -> dict:
+        # `::?<type>` is the dtype-cast counterpart to `::?"%fmt"`: both set the underlying
+        # polars `strict=` flag to False, meaning "on failure, null instead of raise". The
+        # datetime accessors reached through cast syntax (`::hour_of_day`, ...) are extractions,
+        # not conversions, so there is no `strict` to forward and `?` is rejected rather than
+        # silently ignored. Implicit unit casts (`::?minutes`) are rejected in Cast.__post_init__,
+        # which covers the dict form too.
+        input, output_type = items
+        name = str(output_type)
+        if name in DT_CAST_ACCESSORS:
+            raise ValueError(
+                f"Non-strict casting (`::?`) is not supported for accessor {name!r}; `strict` "
+                "applies only to dtype casts."
+            )
+        result = Cast.from_lark([input, Literal.from_lark(output_type)])
+        result[Cast.KEY]["strict"] = Literal.from_lark(False)
+        return result
 
     def coalesce_op(self, items: list[Any]) -> dict:
         # Null-coalescing `left ?? right` is sugar for the existing `coalesce` node. The


### PR DESCRIPTION
Closes #81

`::?` already meant "non-strict" for strptime formats, but the grammar only accepted it before a format string, so `$dose::?float64` was a parse error and `Cast` had no way to express a lenient conversion.

This makes `::?` mean the same thing everywhere, which it can do honestly because both spellings lower onto a polars `strict=` parameter with *identical* semantics — "on failure, produce null instead of raising":

| dftly | polars | `strict=False` |
|---|---|---|
| `$x::?"%Y-%m-%d"` | `.str.strptime(..., strict=)` | unparsable → null |
| `$x::?float64` | `.cast(..., strict=)` | unconvertible → null |

```python
df = pl.DataFrame({"dose": ["25", "1000 MG", ""]})
df.select(**Parser.to_polars({"v": "$dose::?float64"}))   # [25.0, null, null]
```

### Why this matters

The only workaround today is to pre-filter with a regex that reimplements the float grammar. That is unpleasant, but the real hazard is that it's easy to get subtly wrong in a way nothing catches — the obvious first attempt `^-?[0-9]*\.?[0-9]+$` looks right and silently nulls `1e5`, `1.5E-3`, `25.`, `+5`, and inf/NaN. Delegating to polars removes the class of bug entirely.

### Base form

Per AGENTS.md, starting from the base form: `Cast` gains an optional `strict` kwarg, mirroring `Strptime`'s (same name, same meaning, same default of `True`). Its canonical form is now the keyword form:

```yaml
cast:
  source: {column: dose}
  type: {literal: float64}
  strict: {literal: false}
```

The existing positional form `{"cast": [source, type]}` is kept as sugar and normalizes to the keyword form in `__post_init__`, so **existing configs and `Cast(a, b)` call sites are unaffected**. The only visible change is `repr` (`Cast(source=..., type=...)`), updated in the affected doctests.

Mechanically this means `Cast` moves from `BinaryOp` to `KwargsOnlyFn`. It keeps `SYM = "::"` and is registered into `BINARY_OPS` explicitly rather than via the `issubclass(BinaryOp)` scan, so that mapping is unchanged.

### Non-cast targets rejected, not ignored

`strict=False` is an error for targets that don't lower to a real `.cast()`:

- implicit unit casts (`::?minutes`, `::?year`) build values via `pl.duration()` / `pl.date()` — validated in `Cast.__post_init__`, so the dict form is covered too;
- datetime accessors (`::?hour_of_day`) *extract* a component — validated in the grammar layer, since they never reach `Cast`.

Silently ignoring the flag would be exactly the quiet-wrong-answer failure mode the issue is about.

### Drive-by: readable transformer errors

Lark wraps exceptions raised inside transformer methods in a `VisitError` whose message buries the actionable text under a rule name and a chained traceback. `parse_str` now unwraps it. This was needed for the new accessor error, and improves pre-existing paths too — the `substring` step error, `Unsupported function`, and `Unsupported binary operator` all now read as plain `ValueError`s:

```
ValueError: Failed to parse expression '$code[10:30:45]': Slice shorthand does not support step
(got '10:30:45'); use the substring() function form.
```

### Testing

- `uv run pytest` → 75 passed.
- New doctests cover the keyword/positional equivalence, strict default, `::?` in both `::` and `as` spellings, and each rejection path.
- **Differential fuzz against polars**: 3032 strings (hand-picked adversarial cases plus random junk) compared `$s::?float64` to `pl.col("s").cast(pl.Float64, strict=False)` — 0 mismatches. This is the equivalence the issue reports having to pin downstream with a hand-maintained test; it now holds by construction.
- Composition checked: `$a as ?int64`, `$a::?int64 + 1`, `coalesce($a::?float64, 0.0)`, non-strict casts inside conditionals, and chained `($a::?int64)::?float64`.
- No new failures under `polars==1.43.1` (the 2 failures there are pre-existing on `main`; one is fixed by #82, the other is the unrelated `StringInterpolate` column-naming change).

### Docs

New README section documenting `::?` for both casts and strptime, plus the rejection rule. AGENTS.md node-hierarchy list updated for `Cast`'s new base class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)