### PR TITLE
Pin StringInterpolate doctests to an explicit column alias

### DIFF
--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -26,10 +26,10 @@ class StringInterpolate(ArgsOnlyFn):
         │ Alice │
         │ Bob   │
         └───────┘
-        >>> df.select(StringInterpolate(Literal("hello {}"), Column("name")).polars_expr)
+        >>> df.select(StringInterpolate(Literal("hello {}"), Column("name")).polars_expr.alias("greeting"))
         shape: (2, 1)
         ┌─────────────┐
-        │ literal     │
+        │ greeting    │
         │ ---         │
         │ str         │
         ╞═════════════╡
@@ -40,10 +40,12 @@ class StringInterpolate(ArgsOnlyFn):
     The pattern string can also be constructed from other nodes that evaluate to strings:
 
         >>> from dftly.nodes import Add
-        >>> df.select(StringInterpolate(Add(Literal("hello "), Literal("{}")), Column("name")).polars_expr)
+        >>> df.select(
+        ...     StringInterpolate(Add(Literal("hello "), Literal("{}")), Column("name")).polars_expr.alias("greeting")
+        ... )
         shape: (2, 1)
         ┌─────────────┐
-        │ literal     │
+        │ greeting    │
         │ ---         │
         │ str         │
         ╞═════════════╡


### PR DESCRIPTION
Fixes the last thing keeping dftly from passing on current polars. Together with #82, this makes the suite green on **every** polars release from 1.33.0 through 1.43.1.

### What broke

Two `StringInterpolate` doctests selected an *unaliased* expression, so they asserted on polars' auto-derived output column name (`literal`). polars changed that derivation in **1.35.1** — it now names the column after the first referenced column (`name`) — breaking these doctests on every release since.

Nothing about dftly's behavior changed, and **no user is affected**: real usage goes through `df.select(**Parser.to_polars(ops))`, where every column is explicitly aliased by its output key. The doctests were asserting on an incidental detail that was never dftly's to guarantee. Adding an explicit `.alias("greeting")` makes them test the interpolation result instead of polars' naming heuristic.

### Version matrix

I ran the suite against all 19 polars releases >=1.33. On `main` there are two independent breaks:

| polars | `main` | with #82 + this PR |
|---|---|---|
| 1.33.0 – 1.34.0 | pass | pass |
| 1.35.1 – 1.39.3 | `StringInterpolate` fails | pass |
| 1.40.0 – 1.43.1 | `StringInterpolate` + README `Datetime + Duration` fail | pass |

`StringInterpolate` broke at 1.35.1; the `Datetime + Duration` case (#80) broke at 1.40.0.

### Why not pin instead

Pinning was the obvious alternative, but the numbers argue against it. Because the two breaks are independent and the `StringInterpolate` one is older, a pin would have to be `polars<=1.34.0` — not `<=1.39.3` — to get a green suite. That would lock users out of 15 releases to avoid one cosmetic doctest assertion and one real bug that #82 fixes properly at the source. Fixing both leaves `polars>=1.33` with no upper bound, which is the honest constraint.

### Suggested follow-up (not in this PR)

CI only tests the locked polars, which is why both breaks went unnoticed until #80 was filed from the outside. A second `run_tests_ubuntu` job resolving to latest polars (or a scheduled run) would catch this class of drift. Happy to open that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
