### PR TITLE
Bind regex operands at `additive`, not `expr`

### DIFF
--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -233,6 +233,28 @@ class RegexExtract(KwargsOnlyFn):
         Traceback (most recent call last):
             ...
         ValueError: The group_index argument must be an integer or a NodeBase instance ...can't be evaluated...
+
+    In string form, ``extract /re/ from ...`` takes its source at the same ``additive`` level the
+    comparison operators use. The source therefore absorbs arithmetic and casts, but stops at
+    ``if`` / ``and`` / ``or`` -- so a trailing conditional wraps the extraction rather than being
+    swallowed into the string being extracted from:
+
+        >>> from dftly.str_form.parser import DftlyGrammar
+        >>> tree = DftlyGrammar.parse_str("extract /(a)(b)/ from $bp if /(a)(b)/ in $bp")
+        >>> list(tree)
+        ['conditional']
+        >>> list(tree["conditional"]["then"])
+        ['regex_extract']
+
+    Both groupings evaluate the same here (extracting from a null source yields null, exactly as
+    a false condition does), but the conditional-outermost reading is what the text says:
+
+        >>> df = pl.DataFrame({"bp": ["120/80", "NULL", None]})
+        >>> from dftly import Parser
+        >>> df.select(**Parser.to_polars(
+        ...     {"v": r'extract group 1 of /(\\d+)\\/(\\d+)/ from $bp if /(\\d+)\\/(\\d+)/ in $bp'}
+        ... ))["v"].to_list()
+        ['120', None, None]
     """
 
     KEY = "regex_extract"
@@ -320,6 +342,26 @@ class RegexMatch(KwargsOnlyFn):
         │ true  │
         │ false │
         └───────┘
+
+    In string form (``/pattern/ in $source``), this binds like a comparison operator: tighter than
+    ``and`` / ``or`` / ``not``, looser than arithmetic. So conjunctions of matches read the way
+    they look, without needing parentheses on each operand:
+
+        >>> from dftly.str_form.parser import DftlyGrammar
+        >>> DftlyGrammar.parse_str("/^a/ in $x and /^1/ in $y")
+        {'and': [{'regex_match': {'pattern': {'literal': '^a'}, 'source': {'column': 'x'}}},
+                 {'regex_match': {'pattern': {'literal': '^1'}, 'source': {'column': 'y'}}}]}
+        >>> DftlyGrammar.parse_str("/^a/ in $x and not /^1/ in $y")
+        {'and': [{'regex_match': {'pattern': {'literal': '^a'}, 'source': {'column': 'x'}}},
+                 {'not': [{'regex_match': {'pattern': {'literal': '^1'},
+                                           'source': {'column': 'y'}}}]}]}
+
+    Because the operand binds at the same level the comparison operators use, arithmetic on the
+    right-hand side is still absorbed into the source:
+
+        >>> DftlyGrammar.parse_str("/re/ in $a + $b")
+        {'regex_match': {'pattern': {'literal': 're'},
+                         'source': {'add': [{'column': 'a'}, {'column': 'b'}]}}}
     """
 
     KEY = "regex_match"

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -237,9 +237,9 @@ class RegexExtract(KwargsOnlyFn):
         ValueError: The group_index argument must be an integer or a NodeBase instance ...can't be evaluated...
 
     In string form, ``extract /re/ from ...`` takes its source at the same ``additive`` level the
-    comparison operators use. The source therefore absorbs arithmetic and casts, but stops at
-    ``if`` / ``and`` / ``or`` -- so a trailing conditional wraps the extraction rather than being
-    swallowed into the string being extracted from:
+    comparison operators use. The source therefore absorbs arithmetic and *local* ``::`` casts, but
+    stops at ``if`` / ``and`` / ``or`` -- so a trailing conditional wraps the extraction rather than
+    being swallowed into the string being extracted from:
 
         >>> from dftly.str_form.parser import DftlyGrammar
         >>> tree = DftlyGrammar.parse_str("extract /(a)(b)/ from $bp if /(a)(b)/ in $bp")
@@ -257,6 +257,24 @@ class RegexExtract(KwargsOnlyFn):
         ...     {"v": r'extract group 1 of /(\\d+)\\/(\\d+)/ from $bp if /(\\d+)\\/(\\d+)/ in $bp'}
         ... ))["v"].to_list()
         ['120', None, None]
+
+    The ``::`` / ``as`` distinction matters here. A local ``::`` cast is part of the source; an
+    ``as`` cast is the loosest operator in the grammar, so it applies to the *extraction result*:
+
+        >>> list(DftlyGrammar.parse_str(r"extract /\\d+/ from $n::str"))
+        ['regex_extract']
+        >>> list(DftlyGrammar.parse_str(r"extract /\\d+/ from $n as str"))
+        ['cast']
+
+    That is the same rule ``as`` follows everywhere else (``$a + $b as str`` casts the sum), but it
+    means ``as`` cannot be used to coerce a *source* into a string -- extraction would run first and
+    fail on the original dtype. Use ``::`` or parentheses for that:
+
+        >>> num = pl.DataFrame({"n": [123]})
+        >>> num.select(**Parser.to_polars({"v": r'extract /\\d+/ from $n::str'}))["v"].to_list()
+        ['123']
+        >>> num.select(**Parser.to_polars({"v": r'extract /\\d+/ from ($n as str)'}))["v"].to_list()
+        ['123']
     """
 
     KEY = "regex_extract"

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -6,7 +6,9 @@
 //   3. coalesce_expr  — `??` null-coalescing (desugars to the `coalesce` node)
 //   4. bool_or        — `or`, `||`
 //   5. bool_and       — `and`, `&&`  (AND binds tighter than OR, as in Python/SQL/C)
-//   6. comparison     — `==`, `!=`, `>`, `<`, `>=`, `<=`
+//   6. comparison     — `==`, `!=`, `>`, `<`, `>=`, `<=`, and the regex forms
+//                       (`/re/ in ...`, `extract /re/ from ...`), whose operands bind at the
+//                       same `additive` level the comparison operators use
 //   7. additive       — `+`, `-`
 //   8. multiplicative — `*`, `/`
 //   9. exp_expr       — `**` (right-associative)
@@ -167,8 +169,23 @@ FROM.2: /from/i
 ?call_expr: NAME "(" [args] ")"   -> func
 ?args: expr ("," expr)*
 
-?regex: EXTRACT (GROUP INT OF)? REGEX_LITERAL FROM expr -> regex_extract
-      | REGEX_LITERAL IN expr -> regex_match
+// Regex forms. Both take `additive` as their operand rather than `expr`, which is what makes
+// them bind like the comparison operators do.
+//
+// These rules live at `primary` (so `not /re/ in $x` works, and so `extract ...` can appear
+// anywhere a value can), but their operand is a *precedence level*, not a delimited group --
+// there is no closing token to stop it. Using `expr` there meant the operand was parsed at the
+// loosest level, so it swallowed everything to its right:
+//
+//     /^a/ in $x and /^1/ in $y
+//         -> regex_match(^a, source = ($x and regex_match(^1, $y)))    // wrong
+//
+// which then fails at evaluation with "expected String type, got: bool". `additive` is exactly
+// the level `?comparison` gives its own operands, so `in` now binds like `==`: tighter than
+// `and`/`or`/`not`, looser than arithmetic. `/re/ in $a + $b` still reads the whole sum as the
+// operand; `/^a/ in $x and ...` no longer captures the conjunction.
+?regex: EXTRACT (GROUP INT OF)? REGEX_LITERAL FROM additive -> regex_extract
+      | REGEX_LITERAL IN additive -> regex_match
 
 ?primary: regex
         | call_expr


### PR DESCRIPTION
Closes #85

### Root cause

`/re/ in X` and `extract /re/ from X` sit at the `primary` precedence level (the tightest), but took their operand as **`expr` — the loosest level in the grammar**. Neither rule has a closing delimiter to stop the operand, so it swallowed everything to its right:

```
/^a/ in $x and /^1/ in $y
    -> regex_match(^a, source = ($x and regex_match(^1, $y)))
```

The `and` lands on a String operand, hence the reporter's `InvalidOperationError: expected String type, got: bool`. The `not` oddity noted at the end of the issue is the same bug, not a second one — `not /^1/ in $y` on its own already parsed correctly on `main`; it only broke when an `in` to its left had swallowed it.

### Fix

Both rules now take **`additive`**, which is exactly the level `?comparison` gives its own operands (`?comparison: additive OP additive`). So `in` binds like `==`: tighter than `and`/`or`/`not`, looser than arithmetic.

I checked every candidate precedence level for LALR conflicts and behavior. `conditional` is the only one that fails to build (reduce/reduce on `IF`); `comparison` and tighter all fix the reported cases, but `additive` is the right one — `unary` and tighter would silently re-group `/re/ in $a + $b` as `(/re/ in $a) + $b`, whereas `additive` keeps the whole sum as the source, matching today's behavior.

```python
df.select(**Parser.to_polars({
    "and":     '/^a/ in $x and /^1/ in $y',      # true   (was: InvalidOperationError)
    "or":      '/^a/ in $x or  /^1/ in $y',      # true   (was: InvalidOperationError)
    "and_not": '/^a/ in $x and not /^1/ in $y',  # false  (was: InvalidOperationError)
    "mixed":   '/^a/ in $x and $y == "123"',     # true
}))
```

The issue's actual use case — unparenthesised ICD-9/ICD-10 ambiguity classification — now parses and evaluates correctly.

### It also repairs a form-hierarchy violation

This is the part I'd flag for review. The README documents `sys_bp`'s string form and its base form as equivalent, but on `main` they parse to **different trees**:

```python
s = r'extract group 1 of /(\d+)\/(\d+)/ from $bp if /(\d+)\/(\d+)/ in $bp'

# on main
DftlyGrammar.parse_str(s)          # -> {'regex_extract': ...}  conditional buried in `source`
# README's documented base form    # -> {'conditional': ...}    conditional outermost
```

AGENTS.md's central rule is that all three forms reduce to the same base-form tree; this pair didn't. With `additive` the string form produces a tree **identical** to the documented YAML (verified by direct comparison).

Both groupings happen to evaluate the same — extracting from a null source yields null, exactly as a false condition does — which is why it went unnoticed. I confirmed the equivalence explicitly, including the null row:

```
old grouping  ['120', None, None]
new grouping  ['120', None, None]
```

So this is a tree-shape correction with no evaluation change for that expression, but it is a real change to how `extract ... from X if cond` groups. Worth a look in case you'd rather keep the old reading.

### Testing

- `uv run pytest` → 74 passed, no existing doctest needed updating.
- New doctests on `RegexMatch` (conjunction, `not`, and arithmetic-in-source cases) and `RegexExtract` (the conditional grouping plus its evaluation equivalence).
- Merges cleanly with #83, which also touches `grammar.lark`; combined suite passes (75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
