### PR TITLE
PROTOTYPE A: `explode()` marker node hoisted by `to_frame`

### DIFF
--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -52,6 +52,7 @@ from .str import (
     Strptime,
     LenChars,
     Substring,
+    Split,
 )
 from .conditional import Conditional
 from .types import Cast, TYPES
@@ -85,6 +86,7 @@ __nodes = [
     RegexMatch,
     LenChars,
     Substring,
+    Split,
     Conditional,
     Cast,
     Strptime,

--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -55,6 +55,7 @@ from .str import (
     Split,
 )
 from .conditional import Conditional
+from .frame import Explode
 from .types import Cast, TYPES
 
 __nodes = [
@@ -88,6 +89,7 @@ __nodes = [
     Substring,
     Split,
     Conditional,
+    Explode,
     Cast,
     Strptime,
     SetTime,

--- a/src/dftly/nodes/frame.py
+++ b/src/dftly/nodes/frame.py
@@ -1,0 +1,91 @@
+"""Nodes for frame-level (row-multiplying) operations.
+
+These live in their own module because they break the invariant every other node in dftly
+holds to: that a node compiles to a length-preserving ``pl.Expr``. See :class:`Explode`.
+"""
+
+from typing import Any
+
+import polars as pl
+
+from .base import ArgsOnlyFn, NodeBase
+
+
+class Explode(ArgsOnlyFn):
+    """Marks a list-valued expression for expansion into one row per element.
+
+    **This node has no expression form.** Every other dftly node compiles to a ``pl.Expr`` that
+    ``df.select`` can evaluate, which requires it to preserve the frame's height. Explode does
+    not -- it multiplies rows -- so it cannot be handled by ``select`` at all as soon as any
+    other output column exists:
+
+        >>> import polars as pl
+        >>> df = pl.DataFrame({"id": [1, 2], "csv": ["a,b,c", "d"]})
+        >>> df.select(pl.col("csv").str.split(",").explode(), pl.col("id"))
+        Traceback (most recent call last):
+            ...
+        polars.exceptions.ShapeError: ...
+
+    Rather than let that surface as a polars shape error far from its cause, ``polars_expr``
+    refuses outright and points at the frame-level entry point:
+
+        >>> from dftly.nodes import Column
+        >>> Explode(Column("parts")).polars_expr
+        Traceback (most recent call last):
+            ...
+        ValueError: `explode` is a row-multiplying operation with no expression form. ...
+
+    Use :meth:`dftly.Parser.to_frame`, which hoists the marker out of the expression and applies
+    it as ``DataFrame.explode`` after the select -- the only form that repeats the non-exploded
+    columns correctly:
+
+        >>> from dftly import Parser
+        >>> ops = {"id": "$id", "part": 'explode(split($csv, ","))'}
+        >>> Parser.to_frame(df, ops)
+        shape: (4, 2)
+        ┌─────┬──────┐
+        │ id  ┆ part │
+        │ --- ┆ ---  │
+        │ i64 ┆ str  │
+        ╞═════╪══════╡
+        │ 1   ┆ a    │
+        │ 1   ┆ b    │
+        │ 1   ┆ c    │
+        │ 2   ┆ d    │
+        └─────┴──────┘
+
+    Exactly one argument is required:
+
+        >>> Explode(Column("a"), Column("b"))
+        Traceback (most recent call last):
+            ...
+        ValueError: explode requires exactly one argument; got 2
+    """
+
+    KEY = "explode"
+
+    def __post_init__(self):
+        super().__post_init__()
+        if len(self.args) != 1:
+            raise ValueError(
+                f"{self.KEY} requires exactly one argument; got {len(self.args)}"
+            )
+
+    @property
+    def source(self) -> NodeBase:
+        """The list-valued expression to be expanded."""
+        return self.args[0]
+
+    @property
+    def polars_expr(self) -> pl.Expr:
+        raise ValueError(
+            "`explode` is a row-multiplying operation with no expression form. It must appear as "
+            "the outermost node of a top-level output and be compiled with `Parser.to_frame(df, "
+            "ops)`, which applies it as a frame operation after the select."
+        )
+
+    @classmethod
+    def from_lark(cls, items: list[Any]) -> dict[str, Any]:
+        if not isinstance(items, list):
+            items = [items]
+        return {cls.KEY: items}

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -824,3 +824,79 @@ class Substring(KwargsOnlyFn):
                 f"substring expects 2 or 3 positional arguments; got {len(items)}"
             )
         return {cls.KEY: kwargs}
+
+
+class Split(KwargsOnlyFn):
+    """This node splits a string into a ``List(String)`` on a literal separator.
+
+    This node only accepts keyword arguments, and requires "source" and "by" keys. The "source" key is the
+    string node to split, and the "by" key is the separator. Lowers to ``pl.Expr.str.split``.
+
+    The separator is a **literal**, not a regex, so regex metacharacters need no escaping:
+
+        >>> from dftly.nodes import Literal, Column
+        >>> pl.select(Split(source=Literal("a.b.c"), by=Literal(".")).polars_expr).item().to_list()
+        ['a', 'b', 'c']
+
+    Example:
+        >>> df = pl.DataFrame({"codes": ["250.00, E11.9", "038.9, 518.81, J96.0", "486"]})
+        >>> df.select(Split(source=Column("codes"), by=Literal(", ")).polars_expr)
+        shape: (3, 1)
+        ┌──────────────────────────────┐
+        │ codes                        │
+        │ ---                          │
+        │ list[str]                    │
+        ╞══════════════════════════════╡
+        │ ["250.00", "E11.9"]          │
+        │ ["038.9", "518.81", "J96.0"] │
+        │ ["486"]                      │
+        └──────────────────────────────┘
+
+    Empty and null handling is worth being explicit about, since the two differ and neither
+    produces an empty list. Empty elements are preserved, and an empty input string yields a
+    one-element list containing the empty string -- not ``[]``:
+
+        >>> df = pl.DataFrame({"c": ["a,,b", "", None]})
+        >>> df.select(Split(source=Column("c"), by=Literal(",")).polars_expr)["c"].to_list()
+        [['a', '', 'b'], [''], None]
+
+    It parses from string form via the function-call grammar:
+
+        >>> from dftly.str_form.parser import DftlyGrammar
+        >>> DftlyGrammar.parse_str('split($icd9code, ", ")')
+        {'split': {'source': {'column': 'icd9code'}, 'by': {'literal': ', '}}}
+
+    The separator may itself be an expression, not just a literal:
+
+        >>> DftlyGrammar.parse_str("split($a, $sep)")
+        {'split': {'source': {'column': 'a'}, 'by': {'column': 'sep'}}}
+
+    Both required kwargs must be present:
+
+        >>> Split(source=Literal("a,b"))
+        Traceback (most recent call last):
+            ...
+        ValueError: Missing required keys for split: {'by'}
+        >>> Split.from_lark([{"column": "a"}])
+        Traceback (most recent call last):
+            ...
+        ValueError: split expects exactly 2 positional arguments (source, by); got 1
+    """
+
+    KEY = "split"
+    REQUIRED_KWARGS = {"source", "by"}
+
+    @property
+    def polars_expr(self) -> pl.Expr:
+        return self.kwargs["source"].polars_expr.str.split(
+            self.kwargs["by"].polars_expr
+        )
+
+    @classmethod
+    def from_lark(cls, items: list[Any]) -> dict[str, Any]:
+        if len(items) != 2:
+            raise ValueError(
+                f"{cls.KEY} expects exactly 2 positional arguments (source, by); got {len(items)}"
+            )
+        source, by = items
+        return {cls.KEY: {"source": source, "by": by}}

--- a/src/dftly/parser.py
+++ b/src/dftly/parser.py
@@ -322,7 +322,17 @@ class Parser:
             TypeError: data must be a str, Path, or dict; got <class 'int'> instead
         """
         parser = cls()
+        mapping = cls._to_mapping(data)
 
+        exprs = {}
+        for name, value in mapping.items():
+            exprs[name] = parser(value).polars_expr.alias(name)
+
+        return exprs
+
+    @classmethod
+    def _to_mapping(cls, data: str | Path | dict[str, Any]) -> dict[str, Any]:
+        """Normalize a YAML string, file path, or dict into a plain ``{name: expression}`` mapping."""
         if isinstance(data, dict):
             mapping = data
         elif isinstance(data, str):
@@ -347,12 +357,101 @@ class Parser:
             raise ValueError(
                 f"YAML content must be a dictionary at the top level; got {type(mapping)}"
             )
+        return mapping
 
-        exprs = {}
-        for name, value in mapping.items():
-            exprs[name] = parser(value).polars_expr.alias(name)
+    @classmethod
+    def _to_nodes(cls, data: str | Path | dict[str, Any]) -> dict[str, NodeBase]:
+        """Normalize any accepted input into ``{output_name: node}`` without compiling to polars.
 
-        return exprs
+        ``to_polars`` and ``to_frame`` share this so they agree on parsing; only what they do with
+        the resulting nodes differs.
+        """
+        mapping = cls._to_mapping(data)
+        parser = cls()
+        return {name: parser(value) for name, value in mapping.items()}
+
+    @classmethod
+    def to_frame(
+        cls, df: pl.DataFrame, data: str | Path | dict[str, Any]
+    ) -> pl.DataFrame:
+        """Compile and apply ``data`` to ``df``, returning a DataFrame.
+
+        This is the frame-level counterpart to :meth:`to_polars`. It exists because row-multiplying
+        operations cannot be expressed as ``pl.Expr`` at all -- see :class:`dftly.nodes.frame.Explode`.
+        For configs with no such operation it is exactly ``df.select(**to_polars(data))``.
+
+        Examples:
+            >>> df = pl.DataFrame({"id": [1, 2], "csv": ["a,b,c", "d"]})
+            >>> Parser.to_frame(df, {"id": "$id", "n": "$id * 10"})
+            shape: (2, 2)
+            ┌─────┬─────┐
+            │ id  ┆ n   │
+            │ --- ┆ --- │
+            │ i64 ┆ i64 │
+            ╞═════╪═════╡
+            │ 1   ┆ 10  │
+            │ 2   ┆ 20  │
+            └─────┴─────┘
+
+        An ``explode`` marker is hoisted out of the expression and applied after the select, so the
+        non-exploded columns are repeated rather than erroring on a length mismatch:
+
+            >>> Parser.to_frame(df, {"id": "$id", "part": 'explode(split($csv, ","))'})
+            shape: (4, 2)
+            ┌─────┬──────┐
+            │ id  ┆ part │
+            │ --- ┆ ---  │
+            │ i64 ┆ str  │
+            ╞═════╪══════╡
+            │ 1   ┆ a    │
+            │ 1   ┆ b    │
+            │ 1   ┆ c    │
+            │ 2   ┆ d    │
+            └─────┴──────┘
+
+        The marker is only meaningful as the outermost node of an output. Nested inside another
+        expression it has no definable meaning, and is rejected rather than silently ignored:
+
+            >>> Parser.to_frame(df, {"bad": 'len_chars(explode(split($csv, ",")))'})
+            Traceback (most recent call last):
+                ...
+            ValueError: `explode` may only appear as the outermost node of an output; found it
+            nested inside output 'bad'.
+        """
+        from .nodes.frame import Explode
+
+        nodes = cls._to_nodes(data)
+
+        exprs, to_explode = {}, []
+        for name, node in nodes.items():
+            if isinstance(node, Explode):
+                to_explode.append(name)
+                inner = node.source
+            else:
+                inner = node
+            if cls._contains_explode(inner):
+                raise ValueError(
+                    "`explode` may only appear as the outermost node of an output; found it "
+                    f"nested inside output {name!r}."
+                )
+            exprs[name] = inner.polars_expr.alias(name)
+
+        out = df.select(**exprs)
+        return out.explode(to_explode) if to_explode else out
+
+    @classmethod
+    def _contains_explode(cls, node: Any) -> bool:
+        """Recursively test whether ``node`` contains an Explode marker anywhere within it."""
+        from .nodes.frame import Explode
+
+        if isinstance(node, Explode):
+            return True
+        if not isinstance(node, NodeBase):
+            return False
+        children = list(getattr(node, "args", ())) + list(
+            getattr(node, "kwargs", {}).values()
+        )
+        return any(cls._contains_explode(child) for child in children)
 
     @classmethod
     def expr_to_polars(cls, expr: str) -> pl.Expr:


### PR DESCRIPTION
**Draft — exploratory prototype for #88, not intended to merge.** One of two; the sibling is the `_explode` directive.

Stacked on #89 (`split`), since you need a list column to explode. Review only the second commit.

## Spelling

Intent lives inside the expression, next to what produces the list:

```yaml
id: $id
part: 'explode(split($csv, ","))'
```

## How it works

`Explode` is a registered node, so dict form, function-call syntax, and recursive composition checks all come free. The interesting part is that its `polars_expr` **refuses**:

```python
Explode(Column("parts")).polars_expr
# ValueError: `explode` is a row-multiplying operation with no expression form. ...
```

rather than returning something whose length silently disagrees with its siblings. `Parser.to_frame(df, ops)` then hoists the marker out and applies it as `DataFrame.explode` after the select — the only form that repeats the non-exploded columns.

```
id | other | part          id | csv   | other
 1 | X     | a              1 | a,b,c | X
 1 | X     | b       <--    2 | d     | Y
 1 | X     | c              3 | null  | Z
 2 | Y     | d
 3 | Z     | null
```

## Failure modes

All caught at config level, naming the offending output:

```python
Parser.to_frame(df, {"bad": 'len_chars(explode(split($csv, ",")))'})
# ValueError: `explode` may only appear as the outermost node of an output;
#             found it nested inside output 'bad'.

Parser.to_polars({"p": 'explode(split($csv, ","))'})
# ValueError: `explode` is a row-multiplying operation with no expression form. ...
```

## Honest assessment

**The good.** Intent sits with the expression that creates the list, which reads naturally. Registration gives dict form and function syntax for nothing. Nested misuse is caught by a tree walk with a message pointing at the specific output.

**The cost, and it's structural.** This puts a node in `NODES` whose `polars_expr` never returns an expression. AGENTS.md's form hierarchy says class form maps to `pl.Expr` via `polars_expr`; this node has a base form and a class form but no third leg. Anyone enumerating `NODES` now finds one entry that isn't an expression, and every future consumer of the node table has to special-case it.

**Second cost.** The cardinality change is invisible from the top of a config. To know whether a config multiplies rows you must read every expression looking for an `explode(` — which for the `_metadata` blocks this is aimed at is exactly the wrong direction.

## Shared plumbing

`to_polars`'s mapping normalization is factored into `_to_mapping` / `_to_nodes` so `to_frame` parses identically. Prototype B has the same refactor, so the two are directly comparable.

## Known gap (both prototypes)

Ragged multi-column explode surfaces as a raw polars error, since arity isn't knowable statically:

```
ShapeError: exploded columns must have matching element counts
```

Tests: 77 passed.
