### PR TITLE
PROTOTYPE B: `_explode` top-level directive

### DIFF
--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -52,6 +52,7 @@ from .str import (
     Strptime,
     LenChars,
     Substring,
+    Split,
 )
 from .conditional import Conditional
 from .types import Cast, TYPES
@@ -85,6 +86,7 @@ __nodes = [
     RegexMatch,
     LenChars,
     Substring,
+    Split,
     Conditional,
     Cast,
     Strptime,

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -824,3 +824,79 @@ class Substring(KwargsOnlyFn):
                 f"substring expects 2 or 3 positional arguments; got {len(items)}"
             )
         return {cls.KEY: kwargs}
+
+
+class Split(KwargsOnlyFn):
+    """This node splits a string into a ``List(String)`` on a literal separator.
+
+    This node only accepts keyword arguments, and requires "source" and "by" keys. The "source" key is the
+    string node to split, and the "by" key is the separator. Lowers to ``pl.Expr.str.split``.
+
+    The separator is a **literal**, not a regex, so regex metacharacters need no escaping:
+
+        >>> from dftly.nodes import Literal, Column
+        >>> pl.select(Split(source=Literal("a.b.c"), by=Literal(".")).polars_expr).item().to_list()
+        ['a', 'b', 'c']
+
+    Example:
+        >>> df = pl.DataFrame({"codes": ["250.00, E11.9", "038.9, 518.81, J96.0", "486"]})
+        >>> df.select(Split(source=Column("codes"), by=Literal(", ")).polars_expr)
+        shape: (3, 1)
+        ┌──────────────────────────────┐
+        │ codes                        │
+        │ ---                          │
+        │ list[str]                    │
+        ╞══════════════════════════════╡
+        │ ["250.00", "E11.9"]          │
+        │ ["038.9", "518.81", "J96.0"] │
+        │ ["486"]                      │
+        └──────────────────────────────┘
+
+    Empty and null handling is worth being explicit about, since the two differ and neither
+    produces an empty list. Empty elements are preserved, and an empty input string yields a
+    one-element list containing the empty string -- not ``[]``:
+
+        >>> df = pl.DataFrame({"c": ["a,,b", "", None]})
+        >>> df.select(Split(source=Column("c"), by=Literal(",")).polars_expr)["c"].to_list()
+        [['a', '', 'b'], [''], None]
+
+    It parses from string form via the function-call grammar:
+
+        >>> from dftly.str_form.parser import DftlyGrammar
+        >>> DftlyGrammar.parse_str('split($icd9code, ", ")')
+        {'split': {'source': {'column': 'icd9code'}, 'by': {'literal': ', '}}}
+
+    The separator may itself be an expression, not just a literal:
+
+        >>> DftlyGrammar.parse_str("split($a, $sep)")
+        {'split': {'source': {'column': 'a'}, 'by': {'column': 'sep'}}}
+
+    Both required kwargs must be present:
+
+        >>> Split(source=Literal("a,b"))
+        Traceback (most recent call last):
+            ...
+        ValueError: Missing required keys for split: {'by'}
+        >>> Split.from_lark([{"column": "a"}])
+        Traceback (most recent call last):
+            ...
+        ValueError: split expects exactly 2 positional arguments (source, by); got 1
+    """
+
+    KEY = "split"
+    REQUIRED_KWARGS = {"source", "by"}
+
+    @property
+    def polars_expr(self) -> pl.Expr:
+        return self.kwargs["source"].polars_expr.str.split(
+            self.kwargs["by"].polars_expr
+        )
+
+    @classmethod
+    def from_lark(cls, items: list[Any]) -> dict[str, Any]:
+        if len(items) != 2:
+            raise ValueError(
+                f"{cls.KEY} expects exactly 2 positional arguments (source, by); got {len(items)}"
+            )
+        source, by = items
+        return {cls.KEY: {"source": source, "by": by}}

--- a/src/dftly/parser.py
+++ b/src/dftly/parser.py
@@ -322,7 +322,32 @@ class Parser:
             TypeError: data must be a str, Path, or dict; got <class 'int'> instead
         """
         parser = cls()
+        mapping, explode_cols = cls._to_mapping(data)
 
+        if explode_cols:
+            raise ValueError(
+                f"{cls.EXPLODE_KEY!r} requests row expansion of {explode_cols}, which `to_polars` "
+                "cannot honor -- it returns length-preserving expressions for `df.select`. Use "
+                "`Parser.to_frame(df, ops)` instead."
+            )
+
+        exprs = {}
+        for name, value in mapping.items():
+            exprs[name] = parser(value).polars_expr.alias(name)
+
+        return exprs
+
+    EXPLODE_KEY = "_explode"
+
+    @classmethod
+    def _to_mapping(
+        cls, data: str | Path | dict[str, Any]
+    ) -> tuple[dict[str, Any], list[str]]:
+        """Normalize input into ``({name: expression}, explode_columns)``.
+
+        The reserved ``_explode`` key is stripped out here rather than being treated as an output
+        column, so both entry points see the same expression mapping.
+        """
         if isinstance(data, dict):
             mapping = data
         elif isinstance(data, str):
@@ -348,11 +373,94 @@ class Parser:
                 f"YAML content must be a dictionary at the top level; got {type(mapping)}"
             )
 
-        exprs = {}
-        for name, value in mapping.items():
-            exprs[name] = parser(value).polars_expr.alias(name)
+        mapping = dict(mapping)
+        raw = mapping.pop(cls.EXPLODE_KEY, None)
+        if raw is None:
+            explode_cols = []
+        elif isinstance(raw, str):
+            explode_cols = [raw]
+        elif isinstance(raw, list) and all(isinstance(c, str) for c in raw):
+            explode_cols = list(raw)
+        else:
+            raise ValueError(
+                f"{cls.EXPLODE_KEY!r} must be a column name or a list of column names; got {raw!r}"
+            )
 
-        return exprs
+        unknown = [c for c in explode_cols if c not in mapping]
+        if unknown:
+            raise ValueError(
+                f"{cls.EXPLODE_KEY!r} names {unknown}, which are not outputs of this config. "
+                f"Available outputs: {sorted(mapping)}"
+            )
+
+        return mapping, explode_cols
+
+    @classmethod
+    def to_frame(
+        cls, df: pl.DataFrame, data: str | Path | dict[str, Any]
+    ) -> pl.DataFrame:
+        """Compile and apply ``data`` to ``df``, returning a DataFrame.
+
+        This is the frame-level counterpart to :meth:`to_polars`. It exists because row-multiplying
+        operations cannot be expressed as ``pl.Expr`` at all: ``select`` is length-preserving, so an
+        exploded column and an ordinary one cannot coexist in it. With no ``_explode`` key this is
+        exactly ``df.select(**to_polars(data))``.
+
+        Examples:
+            >>> df = pl.DataFrame({"id": [1, 2], "csv": ["a,b,c", "d"]})
+            >>> Parser.to_frame(df, {"id": "$id", "n": "$id * 10"})
+            shape: (2, 2)
+            ┌─────┬─────┐
+            │ id  ┆ n   │
+            │ --- ┆ --- │
+            │ i64 ┆ i64 │
+            ╞═════╪═════╡
+            │ 1   ┆ 10  │
+            │ 2   ┆ 20  │
+            └─────┴─────┘
+
+        Row expansion is declared at the top level of the config, not inside an expression, so the
+        cardinality change is visible without reading the expressions:
+
+            >>> ops = {"id": "$id", "part": 'split($csv, ",")', "_explode": ["part"]}
+            >>> Parser.to_frame(df, ops)
+            shape: (4, 2)
+            ┌─────┬──────┐
+            │ id  ┆ part │
+            │ --- ┆ ---  │
+            │ i64 ┆ str  │
+            ╞═════╪══════╡
+            │ 1   ┆ a    │
+            │ 1   ┆ b    │
+            │ 1   ┆ c    │
+            │ 2   ┆ d    │
+            └─────┴──────┘
+
+        Naming an output that does not exist is caught rather than silently ignored:
+
+            >>> Parser.to_frame(df, {"part": 'split($csv, ",")', "_explode": ["typo"]})
+            Traceback (most recent call last):
+                ...
+            ValueError: '_explode' names ['typo'], which are not outputs of this config. ...
+
+        And ``to_polars`` refuses a config it cannot faithfully compile, rather than dropping the
+        directive on the floor:
+
+            >>> Parser.to_polars({"part": 'split($csv, ",")', "_explode": ["part"]})
+            Traceback (most recent call last):
+                ...
+            ValueError: '_explode' requests row expansion of ['part'], which `to_polars` cannot
+            honor ...
+        """
+        parser = cls()
+        mapping, explode_cols = cls._to_mapping(data)
+
+        exprs = {
+            name: parser(value).polars_expr.alias(name)
+            for name, value in mapping.items()
+        }
+        out = df.select(**exprs)
+        return out.explode(explode_cols) if explode_cols else out
 
     @classmethod
     def expr_to_polars(cls, expr: str) -> pl.Expr:


### PR DESCRIPTION
**Draft — exploratory prototype for #88, not intended to merge.** One of two; the sibling is #90 (`explode()` marker node).

Stacked on #89 (`split`), since you need a list column to explode. Review only the second commit.

## Spelling

Intent lives at the top level of the config, outside any expression:

```yaml
id: $id
part: 'split($csv, ",")'
_explode: [part]
```

## How it works

No new node. The expression language stays entirely length-preserving — nothing about `NODES` or the form hierarchy changes. `_explode` is stripped during mapping normalization so it never looks like an output column, and the same `Parser.to_frame(df, ops)` entry point as #90 applies `DataFrame.explode` after the select.

Identical output to prototype A:

```
id | other | part
 1 | X     | a
 1 | X     | b
 1 | X     | c
 2 | Y     | d
 3 | Z     | null
```

## Failure modes

```python
Parser.to_frame(df, {"part": 'split($csv, ",")', "_explode": ["typo"]})
# ValueError: '_explode' names ['typo'], which are not outputs of this config.
#             Available outputs: ['part']

Parser.to_polars({"part": 'split($csv, ",")', "_explode": ["part"]})
# ValueError: '_explode' requests row expansion of ['part'], which `to_polars`
#             cannot honor -- it returns length-preserving expressions for
#             `df.select`. Use `Parser.to_frame(df, ops)` instead.
```

That second one matters: the directive is never silently dropped, so a config author can't believe rows expanded when they didn't.

## Honest assessment

**The good.** dftly's central invariant — every node compiles to a length-preserving `pl.Expr` — is completely untouched. A frame-level operation is written at frame level, which is simply where it belongs. The cardinality change is visible at the top of the config without reading a single expression. It's also markedly simpler: ~60 lines, no new module, no tree walking, and names are validated against actual outputs.

**The cost.** It reserves a key in the output-name namespace, so a column genuinely named `_explode` becomes unaddressable. It's stringly-typed — the directive references outputs by name rather than being attached to the expression producing them (though a typo does error rather than pass silently). And it doesn't compose: only final outputs can be exploded, never an intermediate.

**Where it's weaker than A.** Exploding a non-list column produces a raw polars error rather than a config-level one:

```
InvalidOperationError: `explode` operation not supported for dtype `str`
```

dftly has no type system to catch that before execution, and unlike A there's no expression context to hang a better message on. Fixable with a dtype check against the selected frame before exploding, which I did not add here.

## Known gap (both prototypes)

Ragged multi-column explode surfaces as a raw polars error, since arity isn't knowable statically:

```
ShapeError: exploded columns must have matching element counts
```

Tests: 76 passed.
