### PR TITLE
Extract `NodeBase.literal_kwarg` for constant-valued kwargs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,10 @@ pre-commit run --all-files
     `_ArgsFn.polars_expr` calls `self.__class__.pl_fn(*args)`, which resolves correctly for a
     plain function and for a classmethod alike.
 - Keyword-only nodes validate via `REQUIRED_KWARGS` and `OPTIONAL_KWARGS` sets.
+- Configuration kwargs that must resolve to a constant outside any polars context (`strict`,
+    `drop_empty`, ...) go through `NodeBase.literal_kwarg(name, type, default=...)` rather than
+    hand-rolling the node/evaluatability/type checks. It produces uniform error messages and
+    rejects `bool` where an `int` is wanted.
 - Custom transformer methods in `DftlyGrammar` (like `cast_expr`, `strptime_nonstrict`) are
     acceptable when the grammar needs to wrap tokens into the base form, but they must still
     produce dicts keyed by the correct node KEY.

--- a/src/dftly/nodes/base.py
+++ b/src/dftly/nodes/base.py
@@ -16,6 +16,9 @@ import polars as pl
 from .utils import validate_dict_keys
 
 
+#: Sentinel for `literal_kwarg`'s `default`, distinguishing "absent" from "defaults to None".
+_REQUIRED = object()
+
 EXPRESSION_KEY = "expression"
 EXPRESSION_TYPE_KEY = "type"
 
@@ -440,6 +443,117 @@ class NodeBase(ABC):
             if isinstance(val, NodeBase):
                 cols |= val.referenced_columns
         return cols
+
+    #: Human-readable names for the types :meth:`literal_kwarg` can check, used in error messages.
+    _LITERAL_TYPE_NAMES: ClassVar[dict[type, str]] = {
+        bool: "boolean",
+        str: "string",
+        int: "integer",
+        float: "float",
+    }
+
+    def literal_kwarg(
+        self,
+        name: str,
+        expected_type: type,
+        *,
+        default: Any = _REQUIRED,
+        type_name: str | None = None,
+    ) -> Any:
+        """Evaluate a keyword argument to a plain Python literal of ``expected_type``.
+
+        Several nodes take configuration arguments that must resolve to a constant outside of any
+        polars context -- ``Strptime``'s and ``Cast``'s ``strict``, ``Split``'s ``drop_empty``.
+        Each needs the same four checks, so they live here rather than being restated per node.
+
+        Args:
+            name: The keyword argument to read.
+            expected_type: The Python type the argument must evaluate to.
+            default: Value to return when the argument is absent. If omitted, absence is an error.
+            type_name: Override for the type's name in error messages.
+
+        Returns:
+            The evaluated literal.
+
+        Raises:
+            ValueError: If the argument is absent with no default, is not a node, cannot be
+                evaluated outside a polars context, or evaluates to the wrong type.
+
+        Examples:
+            >>> class Demo(NodeBase):
+            ...     KEY = "demo"
+            ...     def __post_init__(self): pass
+            ...     @property
+            ...     def polars_expr(self): pass
+            ...     @classmethod
+            ...     def from_lark(cls, items): pass
+            >>> Demo(strict=Literal(False)).literal_kwarg("strict", bool, default=True)
+            False
+
+        The default is returned when the argument is absent, and only then:
+
+            >>> Demo().literal_kwarg("strict", bool, default=True)
+            True
+            >>> Demo().literal_kwarg("strict", bool)
+            Traceback (most recent call last):
+                ...
+            ValueError: The strict argument is required.
+
+        A non-node value, an unevaluatable node, and a wrong-typed result are each distinguished:
+
+            >>> Demo(strict="yes").literal_kwarg("strict", bool)
+            Traceback (most recent call last):
+                ...
+            ValueError: The strict argument must be a NodeBase instance that evaluates to a boolean.
+            >>> Demo(strict=Column("x")).literal_kwarg("strict", bool)
+            Traceback (most recent call last):
+                ...
+            ValueError: The strict argument must evaluate to a boolean.
+            >>> Demo(strict=Literal("yes")).literal_kwarg("strict", bool)
+            Traceback (most recent call last):
+                ...
+            ValueError: The strict argument must be a boolean, got <class 'str'>
+
+        Booleans are not accepted where an integer is wanted, despite ``bool`` subclassing ``int``:
+
+            >>> Demo(n=Literal(3)).literal_kwarg("n", int)
+            3
+            >>> Demo(n=Literal(True)).literal_kwarg("n", int)
+            Traceback (most recent call last):
+                ...
+            ValueError: The n argument must be a integer, got <class 'bool'>
+        """
+        type_name = type_name or self._LITERAL_TYPE_NAMES.get(
+            expected_type, expected_type.__name__
+        )
+
+        node = self.kwargs.get(name, None)
+        if node is None:
+            if default is _REQUIRED:
+                raise ValueError(f"The {name} argument is required.")
+            return default
+
+        if not isinstance(node, NodeBase):
+            raise ValueError(
+                f"The {name} argument must be a NodeBase instance that evaluates to a {type_name}."
+            )
+
+        try:
+            value = pl.select(node.polars_expr).item()
+        except Exception as e:
+            raise ValueError(
+                f"The {name} argument must evaluate to a {type_name}."
+            ) from e
+
+        # bool subclasses int, so an int-typed argument must reject True/False explicitly.
+        wrong_type = not isinstance(value, expected_type) or (
+            expected_type is not bool and isinstance(value, bool)
+        )
+        if wrong_type:
+            raise ValueError(
+                f"The {name} argument must be a {type_name}, got {type(value)}"
+            )
+        return value
 
     @property
     @abstractmethod

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -533,20 +533,7 @@ class Strptime(KwargsOnlyFn):
 
     @property
     def strict(self) -> bool:
-        strict_node = self.kwargs.get("strict", None)
-        if strict_node is None:
-            return True  # default: strict=True for backwards compatibility
-        if not isinstance(strict_node, NodeBase):
-            raise ValueError(
-                "The strict argument must be a NodeBase instance that evaluates to a boolean."
-            )
-        try:
-            val = pl.select(strict_node.polars_expr).item()
-        except Exception as e:
-            raise ValueError("The strict argument must evaluate to a boolean.") from e
-        if not isinstance(val, bool):
-            raise ValueError(f"The strict argument must be a boolean, got {type(val)}")
-        return val
+        return self.literal_kwarg("strict", bool, default=True)
 
     @property
     def polars_expr(self) -> pl.Expr:
@@ -911,24 +898,7 @@ class Split(KwargsOnlyFn):
 
     @property
     def drop_empty(self) -> bool:
-        node = self.kwargs.get("drop_empty", None)
-        if node is None:
-            return False  # default: preserve empty elements, matching pl.Expr.str.split
-        if not isinstance(node, NodeBase):
-            raise ValueError(
-                "The drop_empty argument must be a NodeBase instance that evaluates to a boolean."
-            )
-        try:
-            val = pl.select(node.polars_expr).item()
-        except Exception as e:
-            raise ValueError(
-                "The drop_empty argument must evaluate to a boolean."
-            ) from e
-        if not isinstance(val, bool):
-            raise ValueError(
-                f"The drop_empty argument must be a boolean, got {type(val)}"
-            )
-        return val
+        return self.literal_kwarg("drop_empty", bool, default=False)
 
     @property
     def polars_expr(self) -> pl.Expr:

--- a/src/dftly/nodes/types.py
+++ b/src/dftly/nodes/types.py
@@ -276,20 +276,7 @@ class Cast(KwargsOnlyFn):
 
     @property
     def strict(self) -> bool:
-        strict_node = self.kwargs.get("strict", None)
-        if strict_node is None:
-            return True  # default: strict=True, matching polars
-        if not isinstance(strict_node, NodeBase):
-            raise ValueError(
-                "The strict argument must be a NodeBase instance that evaluates to a boolean."
-            )
-        try:
-            val = pl.select(strict_node.polars_expr).item()
-        except Exception as e:
-            raise ValueError("The strict argument must evaluate to a boolean.") from e
-        if not isinstance(val, bool):
-            raise ValueError(f"The strict argument must be a boolean, got {type(val)}")
-        return val
+        return self.literal_kwarg("strict", bool, default=True)
 
     @property
     def polars_expr(self) -> pl.Expr:


### PR DESCRIPTION
Follow-up to the review note on #89. Pure refactor — no behavior change.

### The duplication

`Strptime.strict`, `Cast.strict`, and `Split.drop_empty` each carried a byte-identical 14-line block doing the same four checks: present, is a node, evaluatable outside a polars context, right type. Every future node taking a constant-valued kwarg would have copied it a fourth time.

```python
# ×3, verbatim
strict_node = self.kwargs.get("strict", None)
if strict_node is None:
    return True
if not isinstance(strict_node, NodeBase):
    raise ValueError("The strict argument must be a NodeBase instance that evaluates to a boolean.")
try:
    val = pl.select(strict_node.polars_expr).item()
except Exception as e:
    raise ValueError("The strict argument must evaluate to a boolean.") from e
if not isinstance(val, bool):
    raise ValueError(f"The strict argument must be a boolean, got {type(val)}")
return val
```

becomes

```python
return self.literal_kwarg("strict", bool, default=True)
```

46 lines of triplicated logic → three one-liners, plus one documented helper.

### The messages are unchanged

`literal_kwarg` generates the same three distinct errors the copies did, parameterized by argument name and type name. **The entire suite passes with no doctest edits** — every existing assertion on those messages still matches verbatim. That was the design constraint, and it's the evidence the refactor is behavior-preserving.

| condition | message |
|---|---|
| not a node | `The strict argument must be a NodeBase instance that evaluates to a boolean.` |
| unevaluatable | `The strict argument must evaluate to a boolean.` |
| wrong type | `The strict argument must be a boolean, got <class 'str'>` |
| absent, no default | `The strict argument is required.` |

### One latent bug fixed

`bool` subclasses `int`, so an int-typed kwarg written with the old pattern would have silently accepted `True` as `1`. The helper rejects that explicitly:

```python
Demo(n=Literal(True)).literal_kwarg("n", int)
# ValueError: The n argument must be a integer, got <class 'bool'>
```

No current call site is int-typed, so this is prophylactic — but it's exactly the kind of thing that would have been copied forward.

### Deliberately left alone

`Strptime.format_str`, `Cast.output_type`, and `RegexExtract.group_index` are superficially similar but have bespoke messages and extra rules (non-negativity, accepting raw `int`s alongside nodes). Folding them in would mean either changing user-facing error text or parameterizing the helper until it saved nothing. Happy to revisit if you'd rather unify the wording across all of them.

### Also

Added a `Key Conventions` line in AGENTS.md so new nodes reach for the helper rather than the copy-paste.

Tests: 77 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)