### PR TITLE
Remove `split`'s `drop_empty` option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,10 +223,10 @@ pre-commit run --all-files
     `_ArgsFn.polars_expr` calls `self.__class__.pl_fn(*args)`, which resolves correctly for a
     plain function and for a classmethod alike.
 - Keyword-only nodes validate via `REQUIRED_KWARGS` and `OPTIONAL_KWARGS` sets.
-- Configuration kwargs that must resolve to a constant outside any polars context (`strict`,
-    `drop_empty`, ...) go through `NodeBase.literal_kwarg(name, type, default=...)` rather than
-    hand-rolling the node/evaluatability/type checks. It produces uniform error messages and
-    rejects `bool` where an `int` is wanted.
+- Configuration kwargs that must resolve to a constant outside any polars context (e.g. `strict`)
+    go through `NodeBase.literal_kwarg(name, type, default=...)` rather than hand-rolling the
+    node/evaluatability/type checks. It produces uniform error messages and rejects `bool` where
+    an `int` is wanted.
 - Custom transformer methods in `DftlyGrammar` (like `cast_expr`, `strptime_nonstrict`) are
     acceptable when the grammar needs to wrap tokens into the base form, but they must still
     produce dicts keyed by the correct node KEY.

--- a/src/dftly/nodes/base.py
+++ b/src/dftly/nodes/base.py
@@ -463,8 +463,8 @@ class NodeBase(ABC):
         """Evaluate a keyword argument to a plain Python literal of ``expected_type``.
 
         Several nodes take configuration arguments that must resolve to a constant outside of any
-        polars context -- ``Strptime``'s and ``Cast``'s ``strict``, ``Split``'s ``drop_empty``.
-        Each needs the same four checks, so they live here rather than being restated per node.
+        polars context -- ``Strptime``'s and ``Cast``'s ``strict``, for instance. Each needs the
+        same four checks, so they live here rather than being restated per node.
 
         Args:
             name: The keyword argument to read.

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -931,43 +931,16 @@ class Split(KwargsOnlyFn):
         Traceback (most recent call last):
             ...
         ValueError: split expects exactly 2 positional arguments (source, by); got 1
-
-    Empty elements can be dropped with the optional ``drop_empty`` kwarg. Polars' ``str.split``
-    has no such option -- it takes only ``inclusive`` -- so this filters the resulting list.
-    ``list.drop_nulls()`` would not serve, since split produces empty *strings*, not nulls:
-
-        >>> df = pl.DataFrame({"c": ["a,,b", ",a,", "", None]})
-        >>> node = Split(source=Column("c"), by=Literal(","), drop_empty=Literal(True))
-        >>> df.select(node.polars_expr)["c"].to_list()
-        [['a', 'b'], ['a'], [], None]
-
-    Note the last two rows: an entirely empty input collapses to an empty list ``[]`` rather than
-    ``['']``, while a null input stays null rather than becoming ``[]``.
-
-    ``drop_empty`` must evaluate to a boolean:
-
-        >>> Split(source=Literal("a,b"), by=Literal(","), drop_empty=Literal("yes")).polars_expr
-        Traceback (most recent call last):
-            ...
-        ValueError: The drop_empty argument must be a boolean, ...
     """
 
     KEY = "split"
     REQUIRED_KWARGS = {"source", "by"}
-    OPTIONAL_KWARGS = {"drop_empty"}
-
-    @property
-    def drop_empty(self) -> bool:
-        return self.literal_kwarg("drop_empty", bool, default=False)
 
     @property
     def polars_expr(self) -> pl.Expr:
-        expr = self.kwargs["source"].polars_expr.str.split(
+        return self.kwargs["source"].polars_expr.str.split(
             self.kwargs["by"].polars_expr
         )
-        if self.drop_empty:
-            expr = expr.list.eval(pl.element().filter(pl.element() != ""))
-        return expr
 
     @classmethod
     def from_lark(cls, items: list[Any]) -> dict[str, Any]:


### PR DESCRIPTION
Backs out the `drop_empty` kwarg added to `split` in #89.

Polars' `str.split` has no keep-empty/keep-null parameter — its full signature is `str.split(by, *, inclusive=False)`. So `drop_empty` was dftly inventing behavior rather than exposing polars', which is the wrong side of the line for a thin lowering layer. Better to wait: if polars adds it, this becomes a pass-through with matching semantics rather than a dftly-specific filter we'd then have to reconcile.

### What changes

`split` returns to plain `pl.Expr.str.split`:

| input | `split(x, ",")` |
|---|---|
| `"a,,b"` | `["a", "", "b"]` |
| `""` | `[""]` |
| `null` | `null` |

Passing `drop_empty` is now rejected by the existing `OPTIONAL_KWARGS` check rather than silently ignored:

```
ValueError: Extra unallowed keys for split: {'drop_empty'}
```

That matters — a config carrying `drop_empty` from the brief window it existed fails loudly instead of quietly keeping empty elements.

### What stays

`NodeBase.literal_kwarg` (#92) is unaffected. It still backs `Strptime.strict` and `Cast.strict`, and remains the documented path for future constant-valued kwargs. Only the `Split` call site and the two docs references to `drop_empty` are removed.

Tests: 77 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)