### PR TITLE
Close the last coverage gaps (99% → 100%)

### DIFF
--- a/src/dftly/nodes/__init__.py
+++ b/src/dftly/nodes/__init__.py
@@ -135,9 +135,53 @@ UNARY_OPS = NodeBase.unique_dict_by_prop(__unary_ops, "SYM")
 # raises at import time if any ``CAST_NAME`` collides with another accessor or with a
 # registered type/unit in ``types.TYPES``, so cast-syntax dispatch can never be silently
 # shadowed by a future addition to either side.
-def _build_dt_cast_accessors() -> dict[str, type]:
+def _build_dt_cast_accessors(nodes: list[type] | None = None) -> dict[str, type]:
+    """Map ``CAST_NAME`` to accessor class for every registered ``_DtAccessor``.
+
+    Args:
+        nodes: The node classes to scan. Defaults to the registered node list; it is a parameter
+            so the collision guards below can be exercised without registering a broken node.
+
+    Returns:
+        A mapping of cast name to accessor class.
+
+    Raises:
+        ValueError: If two accessors declare the same ``CAST_NAME``, or if a ``CAST_NAME``
+            collides with a registered type/unit in ``types.TYPES``.
+
+    Examples:
+        >>> sorted(_build_dt_cast_accessors())[:3]
+        ['day_of_month', 'day_of_week', 'day_of_year']
+
+    Nodes that are not accessors, or that opt out with ``CAST_NAME = None``, are skipped:
+
+        >>> _build_dt_cast_accessors([Add, Column])
+        {}
+
+    Two accessors claiming one name is caught rather than silently letting the later win:
+
+        >>> class Dupe(DtYear):
+        ...     KEY = "dupe"
+        >>> _build_dt_cast_accessors([DtYear, Dupe])
+        Traceback (most recent call last):
+            ...
+        ValueError: Duplicate datetime cast accessor name 'year_of_date': DtYear and Dupe
+
+    So is a name that would be shadowed by a cast target in ``types.TYPES``:
+
+        >>> class Shadowed(DtYear):
+        ...     KEY = "shadowed"
+        ...     CAST_NAME = "minutes"
+        >>> _build_dt_cast_accessors([Shadowed])
+        Traceback (most recent call last):
+            ...
+        ValueError: Datetime cast accessor name 'minutes' for Shadowed collides with a
+        registered type/unit in nodes.types.TYPES
+    """
+    if nodes is None:
+        nodes = __nodes
     accessors: dict[str, type] = {}
-    for cls in __nodes:
+    for cls in nodes:
         if not issubclass(cls, _DtAccessor) or cls.CAST_NAME is None:
             continue
         if cls.CAST_NAME in accessors:

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -827,6 +827,13 @@ class Substring(KwargsOnlyFn):
         Traceback (most recent call last):
             ...
         ValueError: Extra unallowed keys for substring: {'step'}
+
+    ``from_lark`` accepts only the 2- and 3-argument function forms:
+
+        >>> Substring.from_lark([{"column": "code"}])
+        Traceback (most recent call last):
+            ...
+        ValueError: substring expects 2 or 3 positional arguments; got 1
     """
 
     KEY = "substring"

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -188,6 +188,16 @@ class DftlyGrammar(Transformer):
         Traceback (most recent call last):
             ...
         ValueError: Failed to parse literal abc
+
+    The TIME terminal's regex is looser than the set of real times -- it admits an hour like
+    ``29`` -- so ``time_literal`` reports the ones dateutil rejects:
+
+        >>> g.time_literal([Token("TIME", "10:30")])
+        {'literal': datetime.time(10, 30)}
+        >>> g.time_literal([Token("TIME", "29:59")])
+        Traceback (most recent call last):
+            ...
+        ValueError: Failed to parse literal 29:59
         >>> g._send_items([{"literal": 1}, {"literal": 2}], Literal)
         Traceback (most recent call last):
             ...


### PR DESCRIPTION
Pre-release housekeeping. Three uncovered spots on `main`, all reachable from real input and all worth asserting.

| location | branch |
|---|---|
| `Substring.from_lark` | arity guard (`got 1`) |
| `DftlyGrammar.time_literal` | parse-failure branch |
| `_build_dt_cast_accessors` | both collision guards |

**`time_literal` is not merely defensive.** The `TIME` terminal's regex is looser than the set of real times — it admits an hour like `29` — so `29:59` lexes as TIME and then fails in dateutil. That path was live and untested.

**The accessor guards were the wrong way round.** They exist precisely to catch a future mistake (a new accessor shadowing another, or shadowing a cast target in `types.TYPES`), so leaving them unverified defeated the point. `_build_dt_cast_accessors` now takes an optional node list, defaulting to the registered one, so the guards can be exercised without registering a broken node into the real table.

```
TOTAL   924   0   100%
78 passed
```

Also re-verified before release: `pre-commit run --all-files` clean, and the suite passes on polars 1.33.0 / 1.36.1 / 1.40.0 / 1.43.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)