### PR TITLE
Let `::` and `as` casts chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,35 @@ Every datetime/duration accessor also exists as a function-call form — `dt_hou
 `dt_total_seconds($delta)`, etc. — for use in programmatic construction or when the cast
 form doesn't compose cleanly. The two are always equivalent.
 
+### Chaining casts
+
+Casts chain, and read left to right — each one applies to everything to its left, so
+`$col::int::year::datetime` is `(($col::int)::year)::datetime`. There is no alternative grouping
+parentheses could disambiguate here, so they are not required:
+
+```python
+>>> years = pl.DataFrame({"admissionyeargroup": ["2003-2004", "2010-2011"]})
+>>> ops = r"""
+... admit_year: '(extract /2003|2010/ from $admissionyeargroup)::int::year::datetime'
+... """
+>>> years.select(**Parser.to_polars(ops))
+shape: (2, 1)
+┌─────────────────────┐
+│ admit_year          │
+│ ---                 │
+│ datetime[μs]        │
+╞═════════════════════╡
+│ 2003-01-01 00:00:00 │
+│ 2010-01-01 00:00:00 │
+└─────────────────────┘
+
+```
+
+Chaining is sugar only: each link is still its own `cast` node, so the chained form and the
+parenthesized form produce the identical tree. `as` chains the same way (`$col as int as year`),
+and the two spellings can be mixed — with their usual precedence difference, so a `::` link binds
+tighter than surrounding arithmetic while an `as` link does not.
+
 ### Non-strict conversion with `::?`
 
 Real-world source columns are often "mostly" the type they claim to be — a `VARCHAR` dose column

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -84,12 +84,13 @@ FROM.2: /from/i
 
 ?expr: global_cast
 
-// Lowest precedence: global cast with `as`/`@` binds last
-?global_cast: conditional AS NAME   -> cast_expr
-            | conditional AS QUESTION NAME -> cast_expr_nonstrict
-            | conditional AS STRING -> strptime
-            | conditional AS QUESTION STRING -> strptime_nonstrict
-            | conditional AT time_literal   -> binary_expr
+// Lowest precedence: global cast with `as`/`@` binds last.
+// Left-recursive so casts chain (see the `local_cast` note below): `$x as int as year`.
+?global_cast: global_cast AS NAME   -> cast_expr
+            | global_cast AS QUESTION NAME -> cast_expr_nonstrict
+            | global_cast AS STRING -> strptime
+            | global_cast AS QUESTION STRING -> strptime_nonstrict
+            | global_cast AT time_literal   -> binary_expr
             | conditional
 
 ?conditional: expr IF expr (ELSE expr)?   -> conditional
@@ -132,11 +133,18 @@ FROM.2: /from/i
 ?exp_expr: local_cast POWER exp_expr  -> binary_expr
          | local_cast
 
-// Higher precedence: local cast with `::` binds tighter than arithmetic
-?local_cast: unary CAST NAME   -> cast_expr
-           | unary CAST QUESTION NAME -> cast_expr_nonstrict
-           | unary CAST STRING -> strptime
-           | unary CAST QUESTION STRING -> strptime_nonstrict
+// Higher precedence: local cast with `::` binds tighter than arithmetic.
+//
+// Left-recursive, so casts chain and read left to right: `$x::int::year::datetime` is
+// `(($x::int)::year)::datetime`, the same nesting the parenthesized form produces. Each cast
+// applies to everything to its left, so there is no alternative grouping the parens could have
+// been disambiguating -- they were pure ceremony, and (because they nest on the left) appending
+// a step meant re-parenthesizing the whole expression. Chaining is sugar only: every link is
+// still its own `cast` node, so the base form is unchanged.
+?local_cast: local_cast CAST NAME   -> cast_expr
+           | local_cast CAST QUESTION NAME -> cast_expr_nonstrict
+           | local_cast CAST STRING -> strptime
+           | local_cast CAST QUESTION STRING -> strptime_nonstrict
            | unary
 
 ?unary: (NOT_SYM|NOT) unary   -> unary_expr

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -123,6 +123,29 @@ class DftlyGrammar(Transformer):
                   'type': {'literal': 'float64'},
                   'strict': {'literal': False}}}
 
+    Casts chain, and read left to right -- each one applies to everything to its left, so
+    ``$x::int::year`` is ``($x::int)::year``. Chaining is sugar only: each link is still its own
+    ``cast`` node, so the chained and parenthesized spellings give the identical base form:
+
+        >>> DftlyGrammar.parse_str("$yr::int::year") == DftlyGrammar.parse_str("(($yr)::int)::year")
+        True
+        >>> DftlyGrammar.parse_str("$yr::int::year")
+        {'cast': {'source': {'cast': {'source': {'column': 'yr'},
+                                      'type': {'literal': 'int'}}},
+                  'type': {'literal': 'year'}}}
+
+    The ``as`` spelling chains the same way, and the two can be mixed -- with the usual precedence
+    difference, so a ``::`` link binds tighter than surrounding arithmetic while an ``as`` link does
+    not:
+
+        >>> DftlyGrammar.parse_str("$yr as int as year") == DftlyGrammar.parse_str("$yr::int::year")
+        True
+        >>> DftlyGrammar.parse_str("$dosage::?float64::str")
+        {'cast': {'source': {'cast': {'source': {'column': 'dosage'},
+                                      'type': {'literal': 'float64'},
+                                      'strict': {'literal': False}}},
+                  'type': {'literal': 'str'}}}
+
     The datetime accessors reachable through cast syntax extract a component rather than convert a
     value, so there is no strictness to relax and ``?`` is rejected rather than quietly ignored:
 


### PR DESCRIPTION
## What

Makes the `local_cast` (`::`) and `global_cast` (`as`) grammar rules left-recursive, so casts chain:

```
$admissionyeargroup::int::year::datetime
```

instead of

```
(((extract /2003|2010/ from $admissionyeargroup)::int)::year)::datetime
```

## Why

Each cast applies to everything to its left, so there is no alternative grouping the parens could
have been disambiguating — they were pure ceremony. And because they nest on the *left*, adding one
more step meant re-parenthesizing the whole expression rather than appending to it. Inside a quoted
YAML scalar, that leaves the reader counting parens.

## Form hierarchy

Chaining is sugar only. Each link is still its own `cast` node, so the chained spelling and the
parenthesized spelling produce the identical base-form tree — asserted directly in the new
`DftlyGrammar` doctests:

```pycon
>>> DftlyGrammar.parse_str("$yr::int::year") == DftlyGrammar.parse_str("(($yr)::int)::year")
True
```

No `from_lark` changed, no new node, no new transformer method.

## Notes

- `as` was given the same treatment for consistency; it also means `$ts @ 12:00 as str` now parses,
  which it previously did not (`@` produced a `global_cast`, which `as` could not take as input).
- LALR builds cleanly with both rules left-recursive; no precedence-level or conflict changes.
- Strictly additive: every expression that parsed before parses to the same tree.

Refs #98 — this covers the paren-nesting half of the issue. The `::milliseconds` half is a separate
PR; the "`::year` will not take a string" claim did not reproduce (see the issue thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)