### PR TITLE
Add sub-second duration units (`::milliseconds`, `::microseconds`, `::nanoseconds`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ Every other component name (`month_of_year`, `day_of_month`, etc.) follows the s
 Duration values project to numeric totals via `total_<unit>` cast names (`total_seconds`,
 `total_minutes`, `total_hours`, `total_days`, `total_milliseconds`, `total_microseconds`,
 `total_nanoseconds`). This is the dual to the existing `::days` / `::seconds` construction —
-numeric to Duration goes through plural unit names, Duration to numeric goes through
-`total_`-prefixed ones. Combined with datetime subtraction, this covers most time-derived
-feature engineering in one line:
+numeric to Duration goes through plural unit names (`nanoseconds`, `microseconds`, `milliseconds`,
+`seconds`, `minutes`, `hours`, `days`, `weeks`, `months`, `years`), Duration to numeric goes through
+`total_`-prefixed ones, and every unit is available in both directions. Combined with datetime
+subtraction, this covers most time-derived feature engineering in one line:
 
 ```python
 >>> ops = r"""
@@ -188,6 +189,28 @@ shape: (2, 3)
 │ 0                ┆ 0                 ┆ 10.001369 │
 │ 531              ┆ 12744             ┆ 8.54757   │
 └──────────────────┴───────────────────┴───────────┘
+
+```
+
+Sub-second units matter most when a source table records offsets in them. An offset column
+documented as milliseconds can say so directly, rather than being divided into a coarser unit:
+
+```python
+>>> from datetime import datetime
+>>> offsets = pl.DataFrame({
+...     "origin": [datetime(2020, 1, 1), datetime(2021, 6, 15)],
+...     "measuredat": [1500, 90000],  # milliseconds since admission
+... })
+>>> offsets.select(**Parser.to_polars({"measured_time": "$origin + $measuredat::milliseconds"}))
+shape: (2, 1)
+┌─────────────────────────┐
+│ measured_time           │
+│ ---                     │
+│ datetime[μs]            │
+╞═════════════════════════╡
+│ 2020-01-01 00:00:01.500 │
+│ 2021-06-15 00:01:30     │
+└─────────────────────────┘
 
 ```
 

--- a/src/dftly/nodes/types.py
+++ b/src/dftly/nodes/types.py
@@ -51,6 +51,9 @@ SECONDS_PER_YEAR = 365.25 * SECONDS_PER_DAY
 SECONDS_PER_MONTH = SECONDS_PER_YEAR / 12
 
 IMPLICIT_DURATION_TYPES: dict[str, Callable[[pl.Expr], pl.Expr]] = {
+    "nanoseconds": lambda x: pl.duration(nanoseconds=x),
+    "microseconds": lambda x: pl.duration(microseconds=x),
+    "milliseconds": lambda x: pl.duration(milliseconds=x),
     "seconds": lambda x: pl.duration(seconds=x),
     "minutes": lambda x: pl.duration(minutes=x),
     "hours": lambda x: pl.duration(hours=x),
@@ -82,8 +85,11 @@ class Cast(KwargsOnlyFn):
     "str" for "Utf8").
 
     In addition, some custom types are added which resolve to standard polars types through a more complex
-    mapping; in particular, duration units ("seconds", "minutes", "hours", "days", "weeks", "months", "years")
-    convert numeric values into durations, and "year" converts an integer into a date at the start of that year.
+    mapping; in particular, duration units ("nanoseconds", "microseconds", "milliseconds", "seconds",
+    "minutes", "hours", "days", "weeks", "months", "years") convert numeric values into durations, and "year"
+    converts an integer into a date at the start of that year. Each of those units is the dual of the
+    ``total_<unit>`` duration accessor that reads it back out (e.g. ``::milliseconds`` /
+    ``::total_milliseconds``).
 
     The optional ``strict`` argument controls what happens to values that cannot be converted. It mirrors
     :class:`~dftly.nodes.str.Strptime`'s ``strict`` argument, and for the same reason -- both lower onto a
@@ -186,6 +192,22 @@ class Cast(KwargsOnlyFn):
 
         >>> pl.select(Cast(Literal("4"), Literal("weeks")).polars_expr).item()
         datetime.timedelta(days=28)
+
+    Sub-second units are supported as well, so source columns recorded as millisecond (or smaller)
+    offsets can say what the data dictionary says rather than dividing by a power of ten:
+
+        >>> pl.select(Cast(Literal(1500), Literal("milliseconds")).polars_expr).item()
+        datetime.timedelta(seconds=1, microseconds=500000)
+        >>> pl.select(Cast(Literal(1500), Literal("microseconds")).polars_expr).item()
+        datetime.timedelta(microseconds=1500)
+        >>> pl.select(Cast(Literal(1_500_000), Literal("nanoseconds")).polars_expr).item()
+        datetime.timedelta(microseconds=1500)
+
+    ``::nanoseconds`` produces a nanosecond-resolution Duration in polars; it is only the round-trip
+    through Python's ``timedelta`` above that rounds to microseconds:
+
+        >>> pl.select(Cast(Literal(1_500_000), Literal("nanoseconds")).polars_expr).dtypes
+        [Duration(time_unit='ns')]
 
     Months and years are approximated as 30.4375 days and 365.25 days, respectively:
 


### PR DESCRIPTION
## What

Adds `nanoseconds`, `microseconds`, and `milliseconds` to `IMPLICIT_DURATION_TYPES`, so:

```yaml
time: '$_origin + $measuredat::milliseconds'
```

works instead of

```yaml
time: '$_origin + ($measuredat / 1000)::seconds'
```

## Why

`::seconds` … `::years` all existed, but the sub-second units did not — even though the accessors
that read them back out (`dt_total_milliseconds`, `dt_total_microseconds`, `dt_total_nanoseconds`)
already did. That asymmetry meant an offset column documented as milliseconds had to be written as
`/ 1000` in the config, so the config and the data dictionary said different things about the same
value. Dividing is exact, so this is ergonomics rather than correctness — but the unit names are now
symmetric in both directions.

## Form hierarchy

No structural change: this is one more entry in the existing unit table, lowering to the
`pl.duration()` keyword of the same name, exactly as `seconds`/`minutes`/`days` do. `::?milliseconds`
is rejected for the same reason `::?minutes` already is (no `strict` to forward), which
`Cast.__post_init__` handles generically.

## Notes

- `::nanoseconds` yields a `Duration(time_unit='ns')` in polars; the doctest shows both that and the
  microsecond rounding you get when round-tripping through Python's `timedelta`.
- Doctests added to `Cast`; README duration section and a worked millisecond-offset example updated.

Refs #98 — this covers the missing-unit half of the issue. The paren-nesting half is #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)