### PR TITLE
Warn when a regex pattern has capture groups but names none

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,40 @@ The `?` prefix applies only to real dtype casts. The duration/date unit casts (`
 (`::hour_of_day`) extract a component — none of these have a strictness to relax, so `::?minutes`
 and `::?hour_of_day` are errors rather than silent no-ops.
 
+### Regex extraction and capture groups
+
+`extract /re/ from $col` returns the **whole match**. To pull out a capture group, name it with
+`extract group N of /re/ from $col` — the same node, with `group_index` set:
+
+```python
+>>> bands = pl.DataFrame({"agegroup": ["40-49", "80+"]})
+>>> regex_ops = {
+...     "whole_match": r"extract /^[0-9]{2}/ from $agegroup",
+...     "age_lo": r"extract group 1 of /^([0-9]{2})/ from $agegroup",
+...     "age_hi": r"(extract group 1 of /([0-9]{2}).?$/ from $agegroup)::int",
+...     "span": r'f"{extract group 1 of /^([0-9][0-9])/ from $agegroup} to {extract group 1 of /([0-9][0-9]).?$/ from $agegroup}"',
+... }
+>>> bands.select(**Parser.to_polars(regex_ops))
+shape: (2, 4)
+┌─────────────┬────────┬────────┬──────────┐
+│ whole_match ┆ age_lo ┆ age_hi ┆ span     │
+│ ---         ┆ ---    ┆ ---    ┆ ---      │
+│ str         ┆ str    ┆ i32    ┆ str      │
+╞═════════════╪════════╪════════╪══════════╡
+│ 40          ┆ 40     ┆ 49     ┆ 40 to 49 │
+│ 80          ┆ 80     ┆ 80     ┆ 80 to 80 │
+└─────────────┴────────┴────────┴──────────┘
+
+```
+
+Because it is an ordinary expression, the group form chains with `::` and nests inside `f"{...}"`
+just like everything else — no need to break out into an intermediate column.
+
+A pattern that *writes* capture groups but never names one is almost always a request for group 1
+that would silently return the whole match instead, so that combination warns and points at the
+syntax above. To keep the whole match deliberately, either make the group non-capturing (`(?:...)`)
+or ask for it explicitly with `extract group 0 of /re/ from $col`.
+
 ### Position-based string operations
 
 `len_chars($col)` returns the Unicode character count of a string column, and

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -233,12 +233,15 @@ class RegexExtract(KwargsOnlyFn):
 
     Patterns that are not literal-evaluatable (a pattern built from a column, say) cannot be
     inspected, and patterns that polars' Rust regex engine accepts but Python's ``re`` does not are
-    not rejected here -- both are simply left alone:
+    not rejected here -- both are simply left alone. Nor does the inspection leak diagnostics of its
+    own: ``[a~~b]`` makes Python's ``re`` warn about character-class syntax it may adopt later, which
+    is this module's opinion of a pattern polars will match with a different engine:
 
         >>> with warnings.catch_warnings(record=True) as caught:
         ...     warnings.simplefilter("always")
         ...     node = RegexExtract(pattern=Column("pattern_col"), source=Column("agegroup"))
         ...     node = RegexExtract(pattern=Literal(r"(?P<y>[0-9]{4})-(?<m>[0-9]{2})"), source=Column("d"))
+        ...     node = RegexExtract(pattern=Literal(r"[a~~b]"), source=Column("d"))
         >>> caught
         []
 
@@ -344,13 +347,20 @@ class RegexExtract(KwargsOnlyFn):
         ``group_index`` -- including ``0`` for "the whole match, deliberately" -- is taken at its
         word, and a pattern the local ``re`` module cannot compile is left alone rather than second
         guessed, since polars matches with Rust's regex engine, not this one.
+
+        The probe's own diagnostics are suppressed for the same reason its errors are ignored: they
+        are this module's opinion of a pattern polars will match with a different engine.
+        ``re.compile("[a~~b]")`` warns about set syntax Python may adopt later, which says nothing
+        about whether the extraction is right and must not surface as though dftly had an opinion.
         """
         if "group_index" in self.kwargs:
             return
 
         try:
             pattern = pl.select(self.kwargs["pattern"].polars_expr).item()
-            n_groups = re.compile(pattern).groups
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                n_groups = re.compile(pattern).groups
         except Exception:
             return
 

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -1,7 +1,9 @@
 from .base import ArgsOnlyFn, Literal, KwargsOnlyFn, NodeBase
 from typing import ClassVar, Any
 import polars as pl
+import re
 import string
+import warnings
 from .types import DATE_TIME_TYPES
 
 
@@ -161,7 +163,7 @@ class RegexExtract(KwargsOnlyFn):
     This node only accepts keyword arguments, and requires "pattern" and "source" keys, with an optional
     "group_index" key. The "pattern" key is the regex pattern to extract, the "source" key is the target node to
     extract from, and the "group_index" key is the index of the regex group to extract. If not provided, the
-    entire match is extracted.
+    entire match is extracted. In string form, the group is selected with ``extract group N of /re/ from ...``.
 
     The group_index, if provided, must be or evaluate (outside of a polars context) to a non-negative integer.
 
@@ -179,7 +181,8 @@ class RegexExtract(KwargsOnlyFn):
         │ baz456qux │
         └───────────┘
         >>> pattern = Literal(r"([a-z]+)([0-9]+)([a-z]+)")
-        >>> df.select(RegexExtract(pattern=pattern, source=Column("text")).polars_expr)
+        >>> whole = Literal(0)
+        >>> df.select(RegexExtract(pattern=pattern, source=Column("text"), group_index=whole).polars_expr)
         shape: (2, 1)
         ┌───────────┐
         │ text      │
@@ -200,6 +203,44 @@ class RegexExtract(KwargsOnlyFn):
         │ foo  │
         │ baz  │
         └──────┘
+
+    ``group_index`` defaults to 0, the whole match. That default is silent when the pattern has no
+    capture groups, but a pattern that *writes* groups and then does not name one is almost always a
+    request for group 1 that will quietly return the whole match instead -- so that combination warns,
+    naming the syntax that selects a group:
+
+        >>> import warnings
+        >>> with warnings.catch_warnings(record=True) as caught:
+        ...     warnings.simplefilter("always")
+        ...     node = RegexExtract(pattern=Literal(r"([0-9]{2}).?$"), source=Column("agegroup"))
+        >>> print(caught[0].message)
+        Regex pattern '([0-9]{2}).?$' has 1 capture group but no group_index, so the whole match is
+        returned rather than the group. Use `extract group 1 of /([0-9]{2}).?$/ from ...` (base form:
+        `group_index: {literal: 1}`) to select a group; pass `group_index: {literal: 0}` to ask for
+        the whole match explicitly, or make the group non-capturing -- `(?:...)` -- to silence this.
+
+    Naming a group silences it, and so does asking for the whole match explicitly (which is what the
+    ``group_index=Literal(0)`` example above does) or making the group non-capturing:
+
+        >>> with warnings.catch_warnings(record=True) as caught:
+        ...     warnings.simplefilter("always")
+        ...     node = RegexExtract(pattern=Literal(r"([0-9]{2}).?$"), source=Column("agegroup"),
+        ...                         group_index=Literal(1))
+        ...     node = RegexExtract(pattern=Literal(r"(?:[0-9]{2}).?$"), source=Column("agegroup"))
+        ...     node = RegexExtract(pattern=Literal(r"[0-9]{2}.?$"), source=Column("agegroup"))
+        >>> caught
+        []
+
+    Patterns that are not literal-evaluatable (a pattern built from a column, say) cannot be
+    inspected, and patterns that polars' Rust regex engine accepts but Python's ``re`` does not are
+    not rejected here -- both are simply left alone:
+
+        >>> with warnings.catch_warnings(record=True) as caught:
+        ...     warnings.simplefilter("always")
+        ...     node = RegexExtract(pattern=Column("pattern_col"), source=Column("agegroup"))
+        ...     node = RegexExtract(pattern=Literal(r"(?P<y>[0-9]{4})-(?<m>[0-9]{2})"), source=Column("d"))
+        >>> caught
+        []
 
     A negative group index raises an error:
 
@@ -291,6 +332,40 @@ class RegexExtract(KwargsOnlyFn):
             )
         if self.group_index < 0:
             raise ValueError("The group_index argument must be a non-negative integer.")
+
+        self._warn_on_unnamed_capture_groups()
+
+    def _warn_on_unnamed_capture_groups(self) -> None:
+        """Warn when the pattern writes capture groups but no ``group_index`` names one.
+
+        The whole-match default is only surprising in that one combination: the author went to the
+        trouble of parenthesizing part of the pattern and then got the unparenthesized result back,
+        with nothing pointing at the syntax that would have selected the group. Any explicit
+        ``group_index`` -- including ``0`` for "the whole match, deliberately" -- is taken at its
+        word, and a pattern the local ``re`` module cannot compile is left alone rather than second
+        guessed, since polars matches with Rust's regex engine, not this one.
+        """
+        if "group_index" in self.kwargs:
+            return
+
+        try:
+            pattern = pl.select(self.kwargs["pattern"].polars_expr).item()
+            n_groups = re.compile(pattern).groups
+        except Exception:
+            return
+
+        if not n_groups:
+            return
+
+        warnings.warn(
+            f"Regex pattern {pattern!r} has {n_groups} capture "
+            f"{'group' if n_groups == 1 else 'groups'} but no group_index, so the whole match is "
+            "returned rather than the group. Use "
+            f"`extract group 1 of /{pattern}/ from ...` (base form: `group_index: {{literal: 1}}`) "
+            "to select a group; pass `group_index: {literal: 0}` to ask for the whole match "
+            "explicitly, or make the group non-capturing -- `(?:...)` -- to silence this.",
+            stacklevel=2,
+        )
 
     @property
     def group_index(self) -> int:


### PR DESCRIPTION
## What

`RegexExtract` now warns when its pattern contains capture groups and no `group_index` was given —
the one combination where the whole-match default is almost certainly not what the author meant:

```
UserWarning: Regex pattern '([0-9]{2}).?$' has 1 capture group but no group_index, so the whole
match is returned rather than the group. Use `extract group 1 of /([0-9]{2}).?$/ from ...` (base
form: `group_index: {literal: 1}`) to select a group; pass `group_index: {literal: 0}` to ask for
the whole match explicitly, or make the group non-capturing -- `(?:...)` -- to silence this.
```

Plus a README section documenting capture groups, which previously appeared only in the header
example and the node registry.

## Why

Per #99, the string form silently returns the whole match, so `extract /(\d\d)/ from $x` looks like
it should give group 1 and doesn't, with nothing pointing at the syntax that would. The ICD case
in the issue (`123.12345` instead of `123.45`) is exactly this. The warning fires at the moment of
the mistake and names the fix.

## Design notes

- **Not a new node, not new syntax.** `extract group N of /re/ from $x` already exists and already
  sets `group_index` — see the issue thread for why a separate `extract_group` (or an index-less
  `extract group of`, valid only when the pattern has exactly one group) doesn't fit the form
  hierarchy: that validity condition has no base-form representation, so the string form would carry
  a constraint the dict form couldn't express.
- **Warn, don't error.** Whole-match-with-groups is legitimate (alternation, lookaround context), so
  this stays non-breaking. `warnings.filterwarnings` silences it as usual.
- **Warns from `__post_init__`**, so dict form, class form, and string form behave identically.
- **Explicit is respected**: any `group_index` — including `0` — is taken at its word, giving a
  first-class way to say "the whole match, deliberately".
- **Conservative detection**: patterns that aren't literal-evaluatable, or that Python's `re` cannot
  compile, are left alone. Polars matches with Rust's regex engine, so a local compile failure is not
  evidence of a bad pattern.

## Notes

While writing the README example I hit a *separate* pre-existing bug: brace quantifiers inside an
f-string field (`f"{extract /([0-9]{2})/ from $x}"`) fail in `StringInterpolate.from_lark`, because
`string.Formatter().parse` reads the `{2}` as a nested field. Filed separately; the README example
sidesteps it with `[0-9][0-9]`.

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)