### PR TITLE
Add backtick-quoted column references (``$`Variable Name` ``)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,44 @@ shape: (1, 7)
 
 ```
 
+### Column names that aren't identifiers
+
+`$name` covers column names that look like identifiers. Source tables — especially clinical ones —
+routinely ship columns like `Variable Name` or `Unit`, which `$Variable Name` cannot express. Wrap
+those in backticks:
+
+```python
+>>> wide = pl.DataFrame({
+...     "Variable Name": ["HR", "SpO2"],
+...     "Unit": ["bpm", "%"],
+...     "Value 1": [80, 97],
+... })
+>>> quoted_ops = {
+...     "code": 'f"OBS//{$`Variable Name`}//{$`Unit`}"',
+...     "numeric_value": "$`Value 1`::float",
+... }
+>>> wide.select(**Parser.to_polars(quoted_ops))
+shape: (2, 2)
+┌──────────────┬───────────────┐
+│ code         ┆ numeric_value │
+│ ---          ┆ ---           │
+│ str          ┆ f32           │
+╞══════════════╪═══════════════╡
+│ OBS//HR//bpm ┆ 80.0          │
+│ OBS//SpO2//% ┆ 97.0          │
+└──────────────┴───────────────┘
+
+```
+
+This is a quoted spelling of the same `column` node, not a different one, so `` $`a` `` and `$a` are
+interchangeable and the quoted form composes everywhere a column reference can appear — arithmetic,
+casts, regex sources, `f"{...}"` fields.
+
+There is no escape for a literal backtick inside a quoted name, and an empty quoted name (a `$`
+followed by two backticks) is a parse error rather than a reference to a column called `""`. A column
+whose name contains a backtick is still reachable through the dict form, `{column: "..."}`, which has
+no lexer to escape from.
+
 ### Bare words as string literals
 
 When dftly expressions are embedded in YAML config files, string literals normally require awkward

--- a/src/dftly/str_form/grammar.lark
+++ b/src/dftly/str_form/grammar.lark
@@ -71,6 +71,7 @@ AND.2: "and"i
 OR.2: "or"i
 NOT.2: "not"i
 NAME: /[A-Za-z_][A-Za-z0-9_]*/
+BACKTICK_NAME: /`[^`\n]+`/
 IN: /in/i
 REGEX_LITERAL: /\/([^\/\\\n]|\\.)*\//
 LPAR: "("
@@ -189,9 +190,16 @@ FROM.2: /from/i
 ?regex: EXTRACT (GROUP INT OF)? REGEX_LITERAL FROM additive -> regex_extract
       | REGEX_LITERAL IN additive -> regex_match
 
+// `$`Variable Name`` is the quoted spelling of `$name`, for columns whose names are not
+// identifiers (spaces, punctuation, leading digits -- anything `NAME` cannot match). Both
+// alternatives reduce with the same `column` handler, so the two spellings are one node: the
+// backticks are stripped by the `BACKTICK_NAME` terminal transform, exactly as quotes are for
+// `STRING`. There is deliberately no escape for a literal backtick inside the name; such a
+// column is reachable through the dict form (`{column: "..."}`), which has no lexer at all.
 ?primary: regex
         | call_expr
         | (DOLLAR)NAME -> column
+        | (DOLLAR)BACKTICK_NAME -> column
         | (FORMAT_PFX)STRING -> string_interpolate
         | time_literal
         | DATE

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -72,6 +72,35 @@ class DftlyGrammar(Transformer):
         >>> DftlyGrammar.parse_str("$a + $b * 3")
         {'add': [{'column': 'a'}, {'multiply': [{'column': 'b'}, {'literal': 3}]}]}
 
+    Column names that are not identifiers -- spaces, punctuation, a leading digit -- are written
+    with backticks between the ``$`` and the name. This is the same node, just a quoted spelling of
+    it, so the two forms are interchangeable and a backtick-quoted identifier means what it says:
+
+        >>> DftlyGrammar.parse_str("$`Variable Name`")
+        {'column': 'Variable Name'}
+        >>> DftlyGrammar.parse_str("$`a`") == DftlyGrammar.parse_str("$a")
+        True
+
+    It composes like any other column reference -- in arithmetic, under casts, and inside
+    ``f"{...}"`` interpolation:
+
+        >>> DftlyGrammar.parse_str("$`Variable Name`::float + 1")
+        {'add': [{'cast': {'source': {'column': 'Variable Name'},
+                           'type': {'literal': 'float'}}}, {'literal': 1}]}
+        >>> DftlyGrammar.parse_str('f"OBS//{$`Variable Name`}"')
+        {'string_interpolate': [{'literal': 'OBS//{}'}, '$`Variable Name`']}
+
+    There is no escape for a literal backtick inside a quoted name, and an empty name is a parse
+    error rather than a reference to a column called ``""``:
+
+        >>> DftlyGrammar.parse_str("$``")
+        Traceback (most recent call last):
+            ...
+        ValueError: Failed to parse expression '$``': No terminal matches '`' ...
+
+    Such a column is still reachable through the dict form (``{"column": "..."}``), which has no
+    lexer to escape from.
+
     Strings will be parsed into string nodes:
 
         >>> DftlyGrammar.parse_str("'hello' + ' ' + 'world'")
@@ -297,6 +326,11 @@ class DftlyGrammar(Transformer):
 
     def NAME(self, val: Token) -> str:
         return str(val)
+
+    def BACKTICK_NAME(self, val: Token) -> str:
+        # `$`Variable Name`` reduces through the same `column` rule as `$name`; strip the
+        # delimiters here so both spellings hand the handler a bare column name.
+        return str(val)[1:-1]
 
     def args(self, items: list[Any]) -> list[Any]:
         return items


### PR DESCRIPTION
## What

Adds a quoted spelling for column references, so names that aren't identifiers are reachable from
string form:

```yaml
code: 'f"OBS//{$`Variable Name`}//{$`Unit`}"'
numeric_value: '$`Value 1`::float'
```

## Why

Per #96 there was no string-form escape at all — `$Variable Name` fails to lex and every convention
tried in the issue (`${...}`, `$'...'`, `$"..."`, `$[...]`) failed too. Because every consumer of a
column in a MESSY config is a dftly expression, a table shipping `Variable Name` could carry the
column but never read it, leaving a pre-MEDS rename as the only workaround — exactly the code
`_table.cols` / `_table.join` exist to delete.

Backticks over `${...}`: `{`/`}` are already meaningful in `f"{...}"` fields, and the issue's own
example (``f"OBS//{${Variable Name}}"``) shows the brace-nesting that follows. Backticks are inert in
the lexer and are the SQL/Markdown convention for exactly this.

## Form hierarchy

Both alternatives reduce with the *same* `column` handler, so this is one node with two spellings,
not a new node:

```pycon
>>> DftlyGrammar.parse_str("$`a`") == DftlyGrammar.parse_str("$a")
True
>>> DftlyGrammar.parse_str("$`Variable Name`")
{'column': 'Variable Name'}
```

The base form (`{column: "Variable Name"}`) already supported these names and is unchanged; this
only closes the string-form gap.

## Scope decisions

- **No escape for a literal backtick inside a name**, and an empty quoted name is a parse error.
  Both stay expressible via the dict form, which has no lexer to escape from — cheaper than an
  escape mechanism nobody will hit.
- **Composes everywhere** a column reference can: arithmetic, casts, regex sources, and `f"{...}"`
  fields (the interpolation path re-parses each field as a full expression, so it came for free —
  covered by a README doctest).

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)