### PR TITLE
Parse f-string fields by brace matching, not `string.Formatter`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ src/dftly/
   str_form/
     grammar.lark        -- LALR(1) grammar for string expressions
     parser.py           -- DftlyGrammar (Lark Transformer: tokens -> base-form dicts)
+    interpolation.py    -- f-string field splitting (boundaries found with the grammar's lexer)
 ```
 
 ### Parsing Pipeline
@@ -244,13 +245,14 @@ pre-commit run --all-files
 
 ## Important Files
 
-| File                              | Purpose                                                |
-| --------------------------------- | ------------------------------------------------------ |
-| `src/dftly/__init__.py`           | Public API exports                                     |
-| `src/dftly/parser.py`             | Parser class and YAML/dict entry points                |
-| `src/dftly/nodes/base.py`         | NodeBase hierarchy and terminal nodes                  |
-| `src/dftly/nodes/__init__.py`     | Node registration (`NODES`, `BINARY_OPS`, `UNARY_OPS`) |
-| `src/dftly/str_form/grammar.lark` | LALR(1) expression grammar                             |
-| `src/dftly/str_form/parser.py`    | `DftlyGrammar` Lark transformer                        |
-| `conftest.py`                     | Doctest namespace fixtures                             |
-| `pyproject.toml`                  | Project config, test settings, dependencies            |
+| File                                  | Purpose                                                |
+| ------------------------------------- | ------------------------------------------------------ |
+| `src/dftly/__init__.py`               | Public API exports                                     |
+| `src/dftly/parser.py`                 | Parser class and YAML/dict entry points                |
+| `src/dftly/nodes/base.py`             | NodeBase hierarchy and terminal nodes                  |
+| `src/dftly/nodes/__init__.py`         | Node registration (`NODES`, `BINARY_OPS`, `UNARY_OPS`) |
+| `src/dftly/str_form/grammar.lark`     | LALR(1) expression grammar                             |
+| `src/dftly/str_form/parser.py`        | `DftlyGrammar` Lark transformer                        |
+| `src/dftly/str_form/interpolation.py` | f-string field splitting via the grammar's lexer       |
+| `conftest.py`                         | Doctest namespace fixtures                             |
+| `pyproject.toml`                      | Project config, test settings, dependencies            |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,8 @@ src/dftly/
   str_form/
     grammar.lark        -- LALR(1) grammar for string expressions
     parser.py           -- DftlyGrammar (Lark Transformer: tokens -> base-form dicts)
-    interpolation.py    -- f-string field splitting (boundaries found with the grammar's lexer)
+    grammar.py          -- the compiled Lark grammar, shared by the modules below
+    interpolation.py    -- f-string field splitting (boundaries found by parsing, not brace counting)
 ```
 
 ### Parsing Pipeline

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ and `::?hour_of_day` are errors rather than silent no-ops.
 ...     "whole_match": r"extract /^[0-9]{2}/ from $agegroup",
 ...     "age_lo": r"extract group 1 of /^([0-9]{2})/ from $agegroup",
 ...     "age_hi": r"(extract group 1 of /([0-9]{2}).?$/ from $agegroup)::int",
-...     "span": r'f"{extract group 1 of /^([0-9][0-9])/ from $agegroup} to {extract group 1 of /([0-9][0-9]).?$/ from $agegroup}"',
+...     "span": r'f"{extract group 1 of /^([0-9]{2})/ from $agegroup} to {extract group 1 of /([0-9]{2}).?$/ from $agegroup}"',
 ... }
 >>> bands.select(**Parser.to_polars(regex_ops))
 shape: (2, 4)
@@ -300,6 +300,39 @@ A pattern that *writes* capture groups but never names one is almost always a re
 that would silently return the whole match instead, so that combination warns and points at the
 syntax above. To keep the whole match deliberately, either make the group non-capturing (`(?:...)`)
 or ask for it explicitly with `extract group 0 of /re/ from $col`.
+
+### What goes inside `f"{...}"`
+
+Every `{...}` field holds a full dftly expression, taken verbatim — casts, regex forms with brace
+quantifiers, subscripts, `??`, conditionals:
+
+```python
+>>> interp_df = pl.DataFrame({"dose": [3.7], "icd": ["12345"], "unit": [None]})
+>>> interp_ops = {
+...     "rounded": 'f"dose={$dose::int}"',
+...     "dotted": r'f"{extract group 1 of /^([0-9]{3})/ from $icd}.{$icd[3:]}"',
+...     "guarded": '''f"{$icd}//{$unit ?? 'UNK'}"''',
+...     "braced": 'f"{{{$icd}}}"',
+... }
+>>> interp_df.select(**Parser.to_polars(interp_ops))
+shape: (1, 4)
+┌─────────┬────────┬────────────┬─────────┐
+│ rounded ┆ dotted ┆ guarded    ┆ braced  │
+│ ---     ┆ ---    ┆ ---        ┆ ---     │
+│ str     ┆ str    ┆ str        ┆ str     │
+╞═════════╪════════╪════════════╪═════════╡
+│ dose=3  ┆ 123.45 ┆ 12345//UNK ┆ {12345} │
+└─────────┴────────┴────────────┴─────────┘
+
+```
+
+Braces nest inside a field (so `{2}` quantifiers work) and are ignored inside quoted strings, so
+`f"{$a ?? '}'}"` means what it looks like. Literal braces are doubled, as in Python: `{{` and `}}`.
+
+Python's format-spec and conversion syntax (`{x:>10}`, `{x!r}`) is **not** supported — a `:` or `!`
+inside a field is ordinary dftly syntax, which is what makes `f"{$dose::int}"` a cast rather than a
+field named `$dose` with a `:int` format spec. Unmatched or empty braces are parse errors rather
+than silently reinterpreted text.
 
 ### Position-based string operations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "pre-commit<4", "ruff", "pytest", "pytest-cov", "pretty-print-directory"
+  "pre-commit<4", "ruff", "pytest", "pytest-cov", "pretty-print-directory", "hypothesis"
 ] # Add your development (lint, test) dependencies here
 
 [tool.setuptools_scm]

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -5,122 +5,9 @@ import re
 import warnings
 from .types import DATE_TIME_TYPES
 
-
-def _scan_interpolation_field(pattern: str, start: int) -> tuple[str, int]:
-    """Return the text of the field beginning at ``start`` and the index just past its ``}``.
-
-    ``start`` is the index of the first character *inside* the opening brace. Braces nest and are
-    ignored inside quoted strings, so a field can contain both a regex quantifier and a string
-    literal holding a brace:
-
-        >>> _scan_interpolation_field("{extract /([0-9]{2})/ from $x} rest", 1)
-        ('extract /([0-9]{2})/ from $x', 30)
-        >>> _scan_interpolation_field("{$a ?? '}'}", 1)
-        ("$a ?? '}'", 11)
-
-    An unterminated field is an error rather than a silently truncated expression:
-
-        >>> _scan_interpolation_field("{$a", 1)
-        Traceback (most recent call last):
-            ...
-        ValueError: Unterminated interpolation field starting at position 0 of '{$a'; ...
-    """
-    depth = 0
-    quote = None
-    i = start
-
-    while i < len(pattern):
-        char = pattern[i]
-        if quote is not None:
-            # Mirrors the STRING terminal in grammar.lark, where a backslash escapes any character.
-            if char == "\\":
-                i += 2
-                continue
-            if char == quote:
-                quote = None
-        elif char in "'\"":
-            quote = char
-        elif char == "{":
-            depth += 1
-        elif char == "}":
-            if depth == 0:
-                return pattern[start:i], i + 1
-            depth -= 1
-        i += 1
-
-    raise ValueError(
-        f"Unterminated interpolation field starting at position {start - 1} of {pattern!r}; "
-        "every `{` must be closed by a matching `}`, or doubled (`{{`) for a literal brace."
-    )
-
-
-def _split_interpolation(pattern: str) -> tuple[str, list[str]]:
-    """Split an f-string pattern into a ``pl.format`` pattern and its field expressions.
-
-    Each ``{...}`` becomes a ``{}`` placeholder and contributes its contents, verbatim, as a field
-    to be parsed as a full dftly expression. ``{{`` and ``}}`` are literal braces, as in Python.
-
-        >>> _split_interpolation("hello {$name}")
-        ('hello {}', ['$name'])
-        >>> _split_interpolation("{{literal}} {$a} and {$b}")
-        ('{literal} {} and {}', ['$a', '$b'])
-
-    The contents are *not* split on ``:`` or ``!`` the way ``str.format`` would split a field from
-    its format spec and conversion. Those characters are ordinary dftly syntax -- ``::`` is a cast --
-    and reading them as formatting directives silently dropped half the expression:
-
-        >>> _split_interpolation("{$a::int}")
-        ('{}', ['$a::int'])
-        >>> _split_interpolation("{$dose::?float64} {$code[0:3]}")
-        ('{} {}', ['$dose::?float64', '$code[0:3]'])
-
-    A lone closing brace, and an empty field, are both errors:
-
-        >>> _split_interpolation("a } b")
-        Traceback (most recent call last):
-            ...
-        ValueError: Unmatched `}` at position 2 of 'a } b'; write `}}` for a literal brace.
-        >>> _split_interpolation("a {} b")
-        Traceback (most recent call last):
-            ...
-        ValueError: Empty interpolation field at position 2 of 'a {} b'; ...
-    """
-    out: list[str] = []
-    fields: list[str] = []
-    i = 0
-
-    while i < len(pattern):
-        char = pattern[i]
-
-        if char == "{":
-            if pattern.startswith("{{", i):
-                out.append("{")
-                i += 2
-                continue
-
-            field, i = _scan_interpolation_field(pattern, i + 1)
-            if not field.strip():
-                raise ValueError(
-                    f"Empty interpolation field at position {i - len(field) - 2} of {pattern!r}; "
-                    "each `{...}` must hold a dftly expression."
-                )
-            fields.append(field)
-            out.append("{}")
-            continue
-
-        if char == "}":
-            if pattern.startswith("}}", i):
-                out.append("}")
-                i += 2
-                continue
-            raise ValueError(
-                f"Unmatched `}}` at position {i} of {pattern!r}; write `}}}}` for a literal brace."
-            )
-
-        out.append(char)
-        i += 1
-
-    return "".join(out), fields
+# `from_lark` is the string-form bridge, so it is the one place a node reaches back into
+# `str_form`; the module holds only the lexer-driven field splitter and imports no nodes.
+from ..str_form.interpolation import split_interpolation
 
 
 class StringInterpolate(ArgsOnlyFn):
@@ -279,7 +166,7 @@ class StringInterpolate(ArgsOnlyFn):
                     "When using `from_lark` with a dictionary, the dictionary must resolve to a Literal node."
                 )
             pattern = Literal.args_from_value(pattern)[0][0]
-        pattern, fields = _split_interpolation(pattern)
+        pattern, fields = split_interpolation(pattern)
         pattern_lit = {"literal": pattern}
 
         return {cls.KEY: [pattern_lit] + fields}

--- a/src/dftly/nodes/str.py
+++ b/src/dftly/nodes/str.py
@@ -2,9 +2,125 @@ from .base import ArgsOnlyFn, Literal, KwargsOnlyFn, NodeBase
 from typing import ClassVar, Any
 import polars as pl
 import re
-import string
 import warnings
 from .types import DATE_TIME_TYPES
+
+
+def _scan_interpolation_field(pattern: str, start: int) -> tuple[str, int]:
+    """Return the text of the field beginning at ``start`` and the index just past its ``}``.
+
+    ``start`` is the index of the first character *inside* the opening brace. Braces nest and are
+    ignored inside quoted strings, so a field can contain both a regex quantifier and a string
+    literal holding a brace:
+
+        >>> _scan_interpolation_field("{extract /([0-9]{2})/ from $x} rest", 1)
+        ('extract /([0-9]{2})/ from $x', 30)
+        >>> _scan_interpolation_field("{$a ?? '}'}", 1)
+        ("$a ?? '}'", 11)
+
+    An unterminated field is an error rather than a silently truncated expression:
+
+        >>> _scan_interpolation_field("{$a", 1)
+        Traceback (most recent call last):
+            ...
+        ValueError: Unterminated interpolation field starting at position 0 of '{$a'; ...
+    """
+    depth = 0
+    quote = None
+    i = start
+
+    while i < len(pattern):
+        char = pattern[i]
+        if quote is not None:
+            # Mirrors the STRING terminal in grammar.lark, where a backslash escapes any character.
+            if char == "\\":
+                i += 2
+                continue
+            if char == quote:
+                quote = None
+        elif char in "'\"":
+            quote = char
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            if depth == 0:
+                return pattern[start:i], i + 1
+            depth -= 1
+        i += 1
+
+    raise ValueError(
+        f"Unterminated interpolation field starting at position {start - 1} of {pattern!r}; "
+        "every `{` must be closed by a matching `}`, or doubled (`{{`) for a literal brace."
+    )
+
+
+def _split_interpolation(pattern: str) -> tuple[str, list[str]]:
+    """Split an f-string pattern into a ``pl.format`` pattern and its field expressions.
+
+    Each ``{...}`` becomes a ``{}`` placeholder and contributes its contents, verbatim, as a field
+    to be parsed as a full dftly expression. ``{{`` and ``}}`` are literal braces, as in Python.
+
+        >>> _split_interpolation("hello {$name}")
+        ('hello {}', ['$name'])
+        >>> _split_interpolation("{{literal}} {$a} and {$b}")
+        ('{literal} {} and {}', ['$a', '$b'])
+
+    The contents are *not* split on ``:`` or ``!`` the way ``str.format`` would split a field from
+    its format spec and conversion. Those characters are ordinary dftly syntax -- ``::`` is a cast --
+    and reading them as formatting directives silently dropped half the expression:
+
+        >>> _split_interpolation("{$a::int}")
+        ('{}', ['$a::int'])
+        >>> _split_interpolation("{$dose::?float64} {$code[0:3]}")
+        ('{} {}', ['$dose::?float64', '$code[0:3]'])
+
+    A lone closing brace, and an empty field, are both errors:
+
+        >>> _split_interpolation("a } b")
+        Traceback (most recent call last):
+            ...
+        ValueError: Unmatched `}` at position 2 of 'a } b'; write `}}` for a literal brace.
+        >>> _split_interpolation("a {} b")
+        Traceback (most recent call last):
+            ...
+        ValueError: Empty interpolation field at position 2 of 'a {} b'; ...
+    """
+    out: list[str] = []
+    fields: list[str] = []
+    i = 0
+
+    while i < len(pattern):
+        char = pattern[i]
+
+        if char == "{":
+            if pattern.startswith("{{", i):
+                out.append("{")
+                i += 2
+                continue
+
+            field, i = _scan_interpolation_field(pattern, i + 1)
+            if not field.strip():
+                raise ValueError(
+                    f"Empty interpolation field at position {i - len(field) - 2} of {pattern!r}; "
+                    "each `{...}` must hold a dftly expression."
+                )
+            fields.append(field)
+            out.append("{}")
+            continue
+
+        if char == "}":
+            if pattern.startswith("}}", i):
+                out.append("}")
+                i += 2
+                continue
+            raise ValueError(
+                f"Unmatched `}}` at position {i} of {pattern!r}; write `}}}}` for a literal brace."
+            )
+
+        out.append(char)
+        i += 1
+
+    return "".join(out), fields
 
 
 class StringInterpolate(ArgsOnlyFn):
@@ -89,6 +205,30 @@ class StringInterpolate(ArgsOnlyFn):
         Traceback (most recent call last):
             ...
         ValueError: When using `from_lark` with a dictionary, the dictionary must resolve to a Literal node.
+
+    Each ``{...}`` holds a full dftly expression, taken verbatim -- casts and regex quantifiers
+    included, neither of which survived being split by ``str.format``'s field/format-spec rules:
+
+        >>> from dftly import Parser
+        >>> doses = pl.DataFrame({"dose": [3.7], "icd": ["12345"]})
+        >>> ops = {
+        ...     "rounded": 'f"dose={$dose::int}"',
+        ...     "dotted": r'f"{extract group 1 of /^([0-9]{3})/ from $icd}.{$icd[3:]}"',
+        ... }
+        >>> doses.select(**Parser.to_polars(ops))
+        shape: (1, 2)
+        ┌─────────┬────────┐
+        │ rounded ┆ dotted │
+        │ ---     ┆ ---    │
+        │ str     ┆ str    │
+        ╞═════════╪════════╡
+        │ dose=3  ┆ 123.45 │
+        └─────────┴────────┘
+
+    Literal braces are doubled, as in Python:
+
+        >>> doses.select(**Parser.to_polars({"braced": 'f"{{{$icd}}}"'}))["braced"].to_list()
+        ['{12345}']
     """
 
     KEY = "string_interpolate"
@@ -139,15 +279,7 @@ class StringInterpolate(ArgsOnlyFn):
                     "When using `from_lark` with a dictionary, the dictionary must resolve to a Literal node."
                 )
             pattern = Literal.args_from_value(pattern)[0][0]
-        fields = []
-        fmt_parts = []
-        for literal, field, _, _ in string.Formatter().parse(pattern):
-            fmt_parts.append(literal)
-            if field is not None:
-                fmt_parts.append("{}")
-                fields.append(field)
-
-        pattern = "".join(fmt_parts)
+        pattern, fields = _split_interpolation(pattern)
         pattern_lit = {"literal": pattern}
 
         return {cls.KEY: [pattern_lit] + fields}

--- a/src/dftly/str_form/grammar.py
+++ b/src/dftly/str_form/grammar.py
@@ -1,0 +1,13 @@
+"""The compiled Lark grammar, shared by everything that needs to read dftly's string form.
+
+Kept apart from :mod:`dftly.str_form.parser` so that both the transformer and the f-string field
+splitter can use one compiled grammar without importing each other -- the transformer depends on the
+node classes, and the nodes depend on the splitter.
+"""
+
+from importlib.resources import files
+
+from lark import Lark
+
+GRAMMAR_TEXT = files(__package__).joinpath("grammar.lark").read_text()
+GRAMMAR = Lark(GRAMMAR_TEXT, parser="lalr")

--- a/src/dftly/str_form/interpolation.py
+++ b/src/dftly/str_form/interpolation.py
@@ -1,35 +1,24 @@
 """Splitting ``f"..."`` patterns into a format string and the expressions that fill it.
 
-The grammar lexes an f-string as one opaque ``STRING`` token, so the field boundaries have to be
-recovered from the text afterwards. That question -- "where does this expression end?" -- is a
-lexing question, and the answer is taken from dftly's own lexer rather than re-derived here: a
-``}`` inside a string literal, a regex literal, or a backtick-quoted column name is *inside a
-token*, so the lexer walks past it, and the first ``}`` it cannot lex is the one that closes the
-field. Nothing in this module needs to know how those forms quote or escape their contents.
+The grammar lexes an f-string as one opaque ``STRING`` token, so field boundaries have to be
+recovered from the text afterwards. That question -- "where does this expression end?" -- is answered
+by handing the text to dftly's own parser and seeing where it stops, rather than by scanning for
+braces here. ``}`` is not a terminal anywhere in the grammar, and a ``}`` belonging to a string
+literal, a regex literal, or a backtick-quoted column name is *inside* a token, so the first ``}``
+the parser cannot consume is exactly the one that closes the field.
+
+It has to be the parser and not a bare lexer. dftly's terminals are ambiguous without parser state --
+``/`` starts a regex literal in one position and divides in another -- so lexing alone reads
+``f"{($a / $a)}{extract /0/ from $x}"`` as holding one regex literal that runs from the division
+slash to the one in ``extract``, swallowing the brace that ends the first field. Lark's contextual
+lexer only offers terminals the parser can accept next, which settles it.
 """
 
 from __future__ import annotations
 
-from functools import cache
-from importlib.resources import files
+from lark.exceptions import UnexpectedCharacters, UnexpectedInput
 
-from lark import Lark
-from lark.exceptions import UnexpectedCharacters
-
-GRAMMAR_TEXT = files(__package__).joinpath("grammar.lark").read_text()
-
-
-@cache
-def _field_lexer() -> Lark:
-    """A lexer-only view of the grammar, used to find where an interpolation field ends.
-
-    Built on first use rather than at import: it costs a grammar compile, and an expression set
-    with no f-strings never needs it. ``parser=None`` skips the LALR table construction, and the
-    basic lexer is used because the contextual one resolves terminals from parser state that does
-    not exist here -- irrelevant either way, since only the *position* at which lexing stops is
-    read, never the tokens.
-    """
-    return Lark(GRAMMAR_TEXT, parser=None, lexer="basic")
+from .grammar import GRAMMAR
 
 
 def _find_field_end(pattern: str, start: int) -> int:
@@ -39,8 +28,8 @@ def _find_field_end(pattern: str, start: int) -> int:
         >>> _find_field_end("{$a} rest", 1)
         3
 
-    Braces that belong to a token rather than to the f-string are skipped, because the lexer
-    consumes the whole token -- this is the entire reason for lexing rather than counting braces:
+    Braces belonging to a token rather than to the f-string are passed over, because the parser
+    consumes the whole token -- this is the entire reason for parsing rather than counting braces:
 
         >>> _find_field_end("{extract /a{2}/ from $x}", 1)   # regex quantifier
         23
@@ -51,27 +40,42 @@ def _find_field_end(pattern: str, start: int) -> int:
         >>> _find_field_end("{$`}`}", 1)                     # brace inside a quoted column name
         5
 
-    A field that is never closed, and a character dftly cannot lex at all, are both errors:
+    Division does not open a regex literal, though the two share a character. Only the parser state
+    distinguishes them, which is why this cannot be a lexer-only scan:
+
+        >>> _find_field_end("{($a / $a)}{extract /0/ from $x}", 1)
+        10
+
+    A field that is never closed, and an expression the grammar rejects outright, are both errors:
 
         >>> _find_field_end("{$a", 1)
         Traceback (most recent call last):
             ...
         ValueError: Unterminated interpolation field starting at position 0 of '{$a'; ...
-        >>> _find_field_end("{$a # 1}", 1)
+        >>> _find_field_end("{$a $b}", 1)
         Traceback (most recent call last):
             ...
-        ValueError: Cannot lex '#' at position 4 of '{$a # 1}'...
+        ValueError: Invalid expression in the interpolation field starting at position 0 of ...
     """
     try:
-        list(_field_lexer().lex(pattern[start:]))
+        for _ in GRAMMAR.parse_interactive(pattern[start:]).iter_parse():
+            pass
     except UnexpectedCharacters as e:
         stop = start + e.pos_in_stream
-        if pattern[stop] != "}":
-            raise ValueError(
-                f"Cannot lex {pattern[stop]!r} at position {stop} of {pattern!r}. Interpolation "
-                "fields hold dftly expressions; literal text belongs outside the `{...}`."
-            ) from e
-        return stop
+        if pattern[stop] == "}":
+            return stop
+        raise ValueError(
+            f"Cannot lex {pattern[stop]!r} at position {stop} of {pattern!r}. Interpolation "
+            "fields hold dftly expressions; literal text belongs outside the `{...}`."
+        ) from e
+    except UnexpectedInput as e:
+        # The parser rejected a token before reaching any `}`, so the field is not a dftly
+        # expression at all. Only the field text can be at fault: whatever follows it begins with
+        # the `}` that the *lexer* refuses, which is the branch above.
+        raise ValueError(
+            f"Invalid expression in the interpolation field starting at position {start - 1} of "
+            f"{pattern!r}: {e}"
+        ) from e
 
     raise ValueError(
         f"Unterminated interpolation field starting at position {start - 1} of {pattern!r}; "

--- a/src/dftly/str_form/interpolation.py
+++ b/src/dftly/str_form/interpolation.py
@@ -1,0 +1,149 @@
+"""Splitting ``f"..."`` patterns into a format string and the expressions that fill it.
+
+The grammar lexes an f-string as one opaque ``STRING`` token, so the field boundaries have to be
+recovered from the text afterwards. That question -- "where does this expression end?" -- is a
+lexing question, and the answer is taken from dftly's own lexer rather than re-derived here: a
+``}`` inside a string literal, a regex literal, or a backtick-quoted column name is *inside a
+token*, so the lexer walks past it, and the first ``}`` it cannot lex is the one that closes the
+field. Nothing in this module needs to know how those forms quote or escape their contents.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from importlib.resources import files
+
+from lark import Lark
+from lark.exceptions import UnexpectedCharacters
+
+GRAMMAR_TEXT = files(__package__).joinpath("grammar.lark").read_text()
+
+
+@cache
+def _field_lexer() -> Lark:
+    """A lexer-only view of the grammar, used to find where an interpolation field ends.
+
+    Built on first use rather than at import: it costs a grammar compile, and an expression set
+    with no f-strings never needs it. ``parser=None`` skips the LALR table construction, and the
+    basic lexer is used because the contextual one resolves terminals from parser state that does
+    not exist here -- irrelevant either way, since only the *position* at which lexing stops is
+    read, never the tokens.
+    """
+    return Lark(GRAMMAR_TEXT, parser=None, lexer="basic")
+
+
+def _find_field_end(pattern: str, start: int) -> int:
+    """Return the index of the ``}`` closing the field whose contents begin at ``start``.
+
+    Examples:
+        >>> _find_field_end("{$a} rest", 1)
+        3
+
+    Braces that belong to a token rather than to the f-string are skipped, because the lexer
+    consumes the whole token -- this is the entire reason for lexing rather than counting braces:
+
+        >>> _find_field_end("{extract /a{2}/ from $x}", 1)   # regex quantifier
+        23
+        >>> _find_field_end("{/}/ in $x}", 1)                # brace inside a regex literal
+        10
+        >>> _find_field_end("{$a ?? '}'}", 1)                # brace inside a string literal
+        10
+        >>> _find_field_end("{$`}`}", 1)                     # brace inside a quoted column name
+        5
+
+    A field that is never closed, and a character dftly cannot lex at all, are both errors:
+
+        >>> _find_field_end("{$a", 1)
+        Traceback (most recent call last):
+            ...
+        ValueError: Unterminated interpolation field starting at position 0 of '{$a'; ...
+        >>> _find_field_end("{$a # 1}", 1)
+        Traceback (most recent call last):
+            ...
+        ValueError: Cannot lex '#' at position 4 of '{$a # 1}'...
+    """
+    try:
+        list(_field_lexer().lex(pattern[start:]))
+    except UnexpectedCharacters as e:
+        stop = start + e.pos_in_stream
+        if pattern[stop] != "}":
+            raise ValueError(
+                f"Cannot lex {pattern[stop]!r} at position {stop} of {pattern!r}. Interpolation "
+                "fields hold dftly expressions; literal text belongs outside the `{...}`."
+            ) from e
+        return stop
+
+    raise ValueError(
+        f"Unterminated interpolation field starting at position {start - 1} of {pattern!r}; "
+        "every `{` must be closed by a matching `}`, or doubled (`{{`) for a literal brace."
+    )
+
+
+def split_interpolation(pattern: str) -> tuple[str, list[str]]:
+    """Split an f-string pattern into a ``pl.format`` pattern and its field expressions.
+
+    Each ``{...}`` becomes a ``{}`` placeholder and contributes its contents, verbatim, as a field
+    for the parser to resolve as a full dftly expression. ``{{`` and ``}}`` are literal braces, as
+    in Python.
+
+        >>> split_interpolation("hello {$name}")
+        ('hello {}', ['$name'])
+        >>> split_interpolation("{{literal}} {$a} and {$b}")
+        ('{literal} {} and {}', ['$a', '$b'])
+
+    Contents are *not* split on ``:`` or ``!`` the way ``str.format`` separates a field from its
+    format spec and conversion. Those are ordinary dftly syntax -- ``::`` is a cast -- and reading
+    them as formatting directives silently discarded half the expression:
+
+        >>> split_interpolation("{$dose::?float64} {$code[0:3]}")
+        ('{} {}', ['$dose::?float64', '$code[0:3]'])
+
+    A lone closing brace, and an empty field, are errors:
+
+        >>> split_interpolation("a } b")
+        Traceback (most recent call last):
+            ...
+        ValueError: Unmatched `}` at position 2 of 'a } b'; write `}}` for a literal brace.
+        >>> split_interpolation("a {} b")
+        Traceback (most recent call last):
+            ...
+        ValueError: Empty interpolation field at position 2 of 'a {} b'; ...
+    """
+    out: list[str] = []
+    fields: list[str] = []
+    i = 0
+
+    while i < len(pattern):
+        char = pattern[i]
+
+        if char == "{":
+            if pattern.startswith("{{", i):
+                out.append("{")
+                i += 2
+                continue
+
+            stop = _find_field_end(pattern, i + 1)
+            field = pattern[i + 1 : stop]
+            if not field.strip():
+                raise ValueError(
+                    f"Empty interpolation field at position {i} of {pattern!r}; each `{{...}}` "
+                    "must hold a dftly expression."
+                )
+            fields.append(field)
+            out.append("{}")
+            i = stop + 1
+            continue
+
+        if char == "}":
+            if pattern.startswith("}}", i):
+                out.append("}")
+                i += 2
+                continue
+            raise ValueError(
+                f"Unmatched `}}` at position {i} of {pattern!r}; write `}}}}` for a literal brace."
+            )
+
+        out.append(char)
+        i += 1
+
+    return "".join(out), fields

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -5,11 +5,11 @@ from functools import partial
 from dateutil import parser as dt_parser
 
 
-from importlib.resources import files
 from lark import Lark, Token, Transformer
 from lark.exceptions import VisitError
 from lark.visitors import Discard
 
+from .interpolation import GRAMMAR_TEXT
 from ..nodes import (
     BINARY_OPS,
     UNARY_OPS,
@@ -21,7 +21,6 @@ from ..nodes import (
 )
 
 
-GRAMMAR_TEXT = files(__package__).joinpath("grammar.lark").read_text()
 GRAMMAR = Lark(GRAMMAR_TEXT, parser="lalr")
 
 

--- a/src/dftly/str_form/parser.py
+++ b/src/dftly/str_form/parser.py
@@ -5,11 +5,11 @@ from functools import partial
 from dateutil import parser as dt_parser
 
 
-from lark import Lark, Token, Transformer
+from lark import Token, Transformer
 from lark.exceptions import VisitError
 from lark.visitors import Discard
 
-from .interpolation import GRAMMAR_TEXT
+from .grammar import GRAMMAR
 from ..nodes import (
     BINARY_OPS,
     UNARY_OPS,
@@ -19,9 +19,6 @@ from ..nodes import (
     Coalesce,
     Literal,
 )
-
-
-GRAMMAR = Lark(GRAMMAR_TEXT, parser="lalr")
 
 
 class DftlyGrammar(Transformer):

--- a/tests/test_interpolation_properties.py
+++ b/tests/test_interpolation_properties.py
@@ -1,0 +1,186 @@
+"""Property tests for f-string field splitting.
+
+The invariant: putting an expression inside an interpolation field must not change it. Whatever
+``$x`` parses to on its own, ``f"{$x}"`` must carry exactly that as its field -- so the splitter is
+correct iff it finds the field boundaries and hands the contents through untouched.
+
+Three implementations have broken that property, each in a way the previous one's tests did not cover.
+``str.format``'s field rules truncated contents at the first ``:`` (``$a::int`` became ``$a``, the
+cast silently discarded) and rejected a ``{2}`` quantifier as a nested field. The brace-counting
+scanner that replaced it knew string literals quote their braces, but not that regex literals and
+backtick-quoted column names do too. Lexing without parser state then mistook the ``/`` of a division
+for the start of a regex literal, running one field's boundary into the next -- a case no one wrote
+an example for, and the one this test found on its own.
+
+That progression is the argument for generating rather than enumerating: each fix was checked against
+the failures already known, and each left a differently-shaped one open. The strategy below mixes
+braces into every token type that can hide them, and pairs operators whose characters overlap, so the
+gap does not have to be anticipated to be found.
+
+The generated expressions only need to *parse*; they are never evaluated, and no claim is made about
+what they mean. Regenerating them as text and re-parsing is enough to catch a splitter that drops,
+truncates, or rewrites what it was given.
+"""
+
+import warnings
+
+import pytest
+from hypothesis import assume, example, given, settings
+from hypothesis import strategies as st
+
+from dftly import Parser
+from dftly.str_form.parser import DftlyGrammar
+
+# Column references, including backtick-quoted names holding the braces and spaces that a naive
+# scanner would mistake for field delimiters.
+COLUMNS = st.sampled_from(
+    ["$a", "$b", "$col_1", "$`Variable Name`", "$`{weird}`", "$`a}b`", "$`{`"]
+)
+
+# String literals are single-quoted throughout: the wrapper below is a double-quoted f-string, and
+# the grammar lexes it as one STRING token, so a `"` anywhere inside would end it early. That is a
+# real limitation of the f-string form (see #75), not something this test should paper over.
+LITERALS = st.sampled_from(
+    [
+        "1",
+        "42",
+        "1.5",
+        "true",
+        "false",
+        "'plain'",
+        "'has {brace}'",
+        "'}'",
+        "'{'",
+        "'{{'",
+        "'a b'",
+    ]
+)
+
+# Regex bodies stay within what the REGEX_LITERAL terminal accepts (no `/`, backslash, or newline)
+# and lean on the characters that matter here: braces, both balanced and not.
+REGEX_BODIES = st.text(alphabet="ab01{}()|.^$*+?-", min_size=1, max_size=6)
+
+CAST_TARGETS = st.sampled_from(["int", "str", "float64", "?float64", "days", "year"])
+
+
+def _extend(children: st.SearchStrategy[str]) -> st.SearchStrategy[str]:
+    """Build a larger expression from smaller ones.
+
+    Compound forms are parenthesized so that every draw parses regardless of how its parts bind -- precedence
+    is not what is under test here, and an unparsable draw would only be thrown away.
+    """
+    return st.one_of(
+        st.tuples(
+            children,
+            st.sampled_from(["+", "-", "*", "/", "==", ">", "and", "or", "??"]),
+            children,
+        ).map(lambda t: f"({t[0]} {t[1]} {t[2]})"),
+        st.tuples(children, CAST_TARGETS).map(lambda t: f"({t[0]})::{t[1]}"),
+        st.tuples(children, children).map(lambda t: f"coalesce({t[0]}, {t[1]})"),
+        st.tuples(children, children).map(lambda t: f"min({t[0]}, {t[1]})"),
+        st.tuples(REGEX_BODIES, children).map(
+            lambda t: f"extract /{t[0]}/ from {t[1]}"
+        ),
+        st.tuples(st.integers(0, 2), REGEX_BODIES, children).map(
+            lambda t: f"extract group {t[0]} of /{t[1]}/ from {t[2]}"
+        ),
+        st.tuples(REGEX_BODIES, children).map(lambda t: f"/{t[0]}/ in {t[1]}"),
+        st.tuples(children, st.integers(0, 3), st.integers(4, 9)).map(
+            lambda t: f"({t[0]})[{t[1]}:{t[2]}]"
+        ),
+        st.tuples(children, children, children).map(
+            lambda t: f"({t[0]} if {t[1]} else {t[2]})"
+        ),
+    )
+
+
+EXPRESSIONS = st.recursive(st.one_of(COLUMNS, LITERALS), _extend, max_leaves=4)
+
+# Literal stretches of an f-string pattern, including the doubled braces that stand for one brace.
+LITERAL_TEXT = st.lists(
+    st.sampled_from(["", "OBS//", " ", "x", "{{", "}}", "-", "{{}}"]), max_size=3
+).map("".join)
+
+
+def _parses(expression: str) -> bool:
+    try:
+        DftlyGrammar.parse_str(expression)
+    except Exception:
+        return False
+    return True
+
+
+# Capture groups without a `group_index` warn by design (#99); the strategy generates them freely.
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+
+
+@settings(deadline=None, max_examples=150)
+@given(expression=EXPRESSIONS)
+@example(
+    expression="$a::int"
+)  # cast: silently truncated by `str.format` field splitting
+@example(
+    expression="extract /^([0-9]{2})/ from $a"
+)  # quantifier: rejected as a nested field
+@example(
+    expression="/}/ in $a"
+)  # brace inside a regex literal: truncated by brace counting
+@example(expression="$`a}b`")  # brace inside a backtick column name: likewise
+@example(expression="($a ?? '}')")  # brace inside a string literal
+def test_field_holds_the_same_expression_it_would_alone(expression: str) -> None:
+    """``f"{e}"`` interpolates exactly the node ``e`` parses to on its own."""
+    assume(_parses(expression))
+
+    interpolated = DftlyGrammar.parse_str(f'f"{{{expression}}}"')
+
+    # The base form keeps fields as raw text for the Parser to resolve, so the text must survive
+    # verbatim -- this is the assertion that a truncating splitter fails.
+    assert interpolated == {"string_interpolate": [{"literal": "{}"}, expression]}
+
+    # ... and resolving it must give back the very tree the expression yields when parsed alone.
+    parser = Parser()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        node = parser(interpolated)
+        alone = parser(expression)
+    assert repr(node.args[1]) == repr(alone)
+
+
+@settings(deadline=None, max_examples=75)
+@given(
+    first=EXPRESSIONS,
+    second=EXPRESSIONS,
+    prefix=LITERAL_TEXT,
+    middle=LITERAL_TEXT,
+    suffix=LITERAL_TEXT,
+)
+# Division in one field and a regex literal in the next: lexing without parser state read the two
+# slashes as one regex literal spanning the brace between them. Found by this test, pinned here.
+@example(
+    first="($a / $a)",
+    second="extract /0/ from $a",
+    prefix="",
+    middle="",
+    suffix="",
+)
+def test_fields_and_literal_text_separate_cleanly(
+    first: str, second: str, prefix: str, middle: str, suffix: str
+) -> None:
+    """Literal text keeps its place around fields, with ``{{``/``}}`` standing for single braces."""
+    assume(_parses(first) and _parses(second))
+
+    pattern = f'f"{prefix}{{{first}}}{middle}{{{second}}}{suffix}"'
+    unescape = {"{{": "{", "}}": "}"}
+
+    def literal(text: str) -> str:
+        for escaped, plain in unescape.items():
+            text = text.replace(escaped, plain)
+        return text
+
+    assert DftlyGrammar.parse_str(pattern) == {
+        "string_interpolate": [
+            {"literal": f"{literal(prefix)}{{}}{literal(middle)}{{}}{literal(suffix)}"},
+            first,
+            second,
+        ]
+    }

--- a/tests/test_interpolation_properties.py
+++ b/tests/test_interpolation_properties.py
@@ -31,6 +31,12 @@ from hypothesis import strategies as st
 from dftly import Parser
 from dftly.str_form.parser import DftlyGrammar
 
+# Every terminal and rule in grammar.lark appears below, so a splitter that mishandles any construct
+# dftly can express has a chance of being caught. Two things are deliberately absent: an expression
+# containing the wrapper's own quote character (`"`), which the f-string form genuinely cannot hold
+# (#75), and a second level of f-string nesting, since the grammar has only two quote characters to
+# nest with.
+
 # Column references, including backtick-quoted names holding the braces and spaces that a naive
 # scanner would mistake for field delimiters.
 COLUMNS = st.sampled_from(
@@ -53,6 +59,15 @@ LITERALS = st.sampled_from(
         "'{'",
         "'{{'",
         "'a b'",
+        "2023-01-01",  # DATE
+        "2023-01-01 12:34:56",  # DATETIME
+        "11:32",  # TIME
+        "11:32 a.m.",  # TIME with meridiem
+        "MEDS_BIRTH",  # bare word
+        "min()",  # a call with no arguments at all -- `[args]` is optional in the grammar
+        "f'plain'",  # an f-string with no fields at all
+        "f'{$a}'",  # a nested f-string, one level down
+        "f'x{$a}y{$b}'",
     ]
 )
 
@@ -60,7 +75,64 @@ LITERALS = st.sampled_from(
 # and lean on the characters that matter here: braces, both balanced and not.
 REGEX_BODIES = st.text(alphabet="ab01{}()|.^$*+?-", min_size=1, max_size=6)
 
-CAST_TARGETS = st.sampled_from(["int", "str", "float64", "?float64", "days", "year"])
+# Dtype names, implicit unit names, and the datetime/duration accessors -- every name the cast forms
+# accept -- plus the `?` prefix that marks a cast non-strict.
+CAST_TARGETS = st.sampled_from(
+    [
+        "int",
+        "str",
+        "float64",
+        "?float64",
+        "days",
+        "milliseconds",
+        "year",
+        "date",
+        "hour_of_day",
+        "year_of_date",
+        "total_seconds",
+        "total_microseconds",
+    ]
+)
+
+STRPTIME_FORMATS = st.sampled_from(["'%Y-%m-%d'", "'%Y-%m-%d %H:%M:%S'", "?'%Y'"])
+
+TIMES = st.sampled_from(["11:30", "11:30 a.m.", "23:59:59"])
+
+BINARY_OPS = st.sampled_from(
+    [
+        "+",
+        "-",
+        "*",
+        "/",
+        "**",
+        "==",
+        "!=",
+        ">",
+        "<",
+        ">=",
+        "<=",
+        "and",
+        "&&",
+        "or",
+        "||",
+        "??",
+    ]
+)
+
+UNARY_OPS = st.sampled_from(["not ", "!", "-", "+"])
+
+# Function-call syntax is open to every registered node, so a representative call of each arity is
+# generated rather than all fifty names: the splitter cannot distinguish them, but it can trip over
+# the commas, nesting, and quoted arguments they introduce.
+#
+# `negate($a)` and other one-argument calls do not resolve today, for a reason unrelated to
+# interpolation: the grammar inlines a one-element `args` rule into a bare dict, which the parser
+# reads as keyword arguments (#109). They are generated anyway -- the property below is that a field
+# behaves as the expression does alone, which covers expressions that legitimately fail.
+CALLS_1 = st.sampled_from(
+    ["hash", "signed_hash", "len_chars", "not", "dt_year", "negate", "min"]
+)
+CALLS_2 = st.sampled_from(["min", "max", "mean", "coalesce", "power"])
 
 
 def _extend(children: st.SearchStrategy[str]) -> st.SearchStrategy[str]:
@@ -70,14 +142,22 @@ def _extend(children: st.SearchStrategy[str]) -> st.SearchStrategy[str]:
     is not what is under test here, and an unparsable draw would only be thrown away.
     """
     return st.one_of(
-        st.tuples(
-            children,
-            st.sampled_from(["+", "-", "*", "/", "==", ">", "and", "or", "??"]),
-            children,
-        ).map(lambda t: f"({t[0]} {t[1]} {t[2]})"),
+        st.tuples(children, BINARY_OPS, children).map(
+            lambda t: f"({t[0]} {t[1]} {t[2]})"
+        ),
+        st.tuples(UNARY_OPS, children).map(lambda t: f"({t[0]}{t[1]})"),
+        # Both cast spellings, over dtypes, implicit units, and datetime accessors.
         st.tuples(children, CAST_TARGETS).map(lambda t: f"({t[0]})::{t[1]}"),
-        st.tuples(children, children).map(lambda t: f"coalesce({t[0]}, {t[1]})"),
-        st.tuples(children, children).map(lambda t: f"min({t[0]}, {t[1]})"),
+        st.tuples(children, CAST_TARGETS).map(lambda t: f"({t[0]}) as {t[1]}"),
+        # Strptime, which is a cast whose target is a format string.
+        st.tuples(children, STRPTIME_FORMATS).map(lambda t: f"({t[0]})::{t[1]}"),
+        st.tuples(children, STRPTIME_FORMATS).map(lambda t: f"({t[0]}) as {t[1]}"),
+        # `@` set-time, whose right operand is a bare TIME token.
+        st.tuples(children, TIMES).map(lambda t: f"({t[0]} @ {t[1]})"),
+        st.tuples(CALLS_1, children).map(lambda t: f"{t[0]}({t[1]})"),
+        st.tuples(CALLS_2, children, children).map(lambda t: f"{t[0]}({t[1]}, {t[2]})"),
+        st.tuples(children, children).map(lambda t: f"substring({t[0]}, 0, 3)"),
+        st.tuples(children).map(lambda t: f"split({t[0]}, ',')"),
         st.tuples(REGEX_BODIES, children).map(
             lambda t: f"extract /{t[0]}/ from {t[1]}"
         ),
@@ -85,12 +165,17 @@ def _extend(children: st.SearchStrategy[str]) -> st.SearchStrategy[str]:
             lambda t: f"extract group {t[0]} of /{t[1]}/ from {t[2]}"
         ),
         st.tuples(REGEX_BODIES, children).map(lambda t: f"/{t[0]}/ in {t[1]}"),
+        # All four slice spellings: [i:j], [i:], [:j], [:].
         st.tuples(children, st.integers(0, 3), st.integers(4, 9)).map(
             lambda t: f"({t[0]})[{t[1]}:{t[2]}]"
         ),
+        st.tuples(children, st.integers(0, 3)).map(lambda t: f"({t[0]})[{t[1]}:]"),
+        st.tuples(children, st.integers(4, 9)).map(lambda t: f"({t[0]})[:{t[1]}]"),
+        st.tuples(children).map(lambda t: f"({t[0]})[:]"),
         st.tuples(children, children, children).map(
             lambda t: f"({t[0]} if {t[1]} else {t[2]})"
         ),
+        st.tuples(children, children).map(lambda t: f"({t[0]} if {t[1]})"),
     )
 
 
@@ -114,6 +199,28 @@ def _parses(expression: str) -> bool:
 pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 
+def _resolve(expression_or_tree) -> tuple[str, object]:
+    """Resolve to a node and build its polars expression, or report the failure.
+
+    Both are outcomes a field must reproduce. Building the polars expression is part of it because
+    ``StringInterpolate`` builds one for each of its fields as it is constructed, so an expression
+    that resolves but cannot lower -- ``min()`` with no arguments, say -- has to be compared at the
+    same depth on both sides to be compared fairly.
+
+    Only success or failure is compared, not the exception type: a field's failure is re-raised by
+    the parser as it tries to match the enclosing ``string_interpolate``, so the same underlying
+    problem legitimately surfaces under a different class on the two sides.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        try:
+            node = Parser()(expression_or_tree)
+            node.polars_expr
+            return "ok", node
+        except Exception:  # noqa: BLE001 -- that it failed is the observation, not how
+            return "error", None
+
+
 @settings(deadline=None, max_examples=150)
 @given(expression=EXPRESSIONS)
 @example(
@@ -127,23 +234,27 @@ pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 )  # brace inside a regex literal: truncated by brace counting
 @example(expression="$`a}b`")  # brace inside a backtick column name: likewise
 @example(expression="($a ?? '}')")  # brace inside a string literal
+@example(expression="negate($a)")  # does not resolve on its own either (#109)
 def test_field_holds_the_same_expression_it_would_alone(expression: str) -> None:
-    """``f"{e}"`` interpolates exactly the node ``e`` parses to on its own."""
+    """``f"{e}"`` interpolates exactly what ``e`` means on its own -- errors included."""
     assume(_parses(expression))
 
     interpolated = DftlyGrammar.parse_str(f'f"{{{expression}}}"')
 
     # The base form keeps fields as raw text for the Parser to resolve, so the text must survive
-    # verbatim -- this is the assertion that a truncating splitter fails.
+    # verbatim -- this is the assertion that a truncating splitter fails, and it holds whether or
+    # not the expression goes on to resolve.
     assert interpolated == {"string_interpolate": [{"literal": "{}"}, expression]}
 
-    # ... and resolving it must give back the very tree the expression yields when parsed alone.
-    parser = Parser()
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        node = parser(interpolated)
-        alone = parser(expression)
-    assert repr(node.args[1]) == repr(alone)
+    # Resolving the field must then reach the very tree the expression yields when parsed alone.
+    # Expressions that do not resolve at all (#109, and f-strings with no fields) must not resolve
+    # here either: a splitter that quietly rewrote its input could turn one of those into something
+    # that works, which would be just as wrong as truncating it.
+    alone_outcome, alone = _resolve(expression)
+    field_outcome, interpolation = _resolve(interpolated)
+    assert field_outcome == alone_outcome
+    if alone_outcome == "ok":
+        assert repr(interpolation.args[1]) == repr(alone)
 
 
 @settings(deadline=None, max_examples=75)

--- a/uv.lock
+++ b/uv.lock
@@ -124,6 +124,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "pre-commit" },
     { name = "pretty-print-directory" },
     { name = "pytest" },
@@ -141,6 +142,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis" },
     { name = "pre-commit", specifier = "<4" },
     { name = "pretty-print-directory" },
     { name = "pytest" },
@@ -164,6 +166,71 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.165.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/ba/6a79ef3edd4d32f011267ba709393ba0bb018751fe019032f9b63a3a29fc/hypothesis-6.165.1.tar.gz", hash = "sha256:0fe3ae25bd0b0938d8681eacaa8ebc981761f1387db7bef609b22cfdec848dc2", size = 496225, upload-time = "2026-08-04T21:02:05.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/24/ad0c5136b1d82b6955f79edbc39f7092dced8c09e9b08aec5a3ec02c02b5/hypothesis-6.165.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1a5640b5e52211e6a876a53af28ec292b984bb02a57be1e39fac38f2f28c6921", size = 775946, upload-time = "2026-08-04T21:00:47.014Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4f/c6dc9b300c2da163cc20d857f87e5d7f21240d99f071d1da3c27ac3d6269/hypothesis-6.165.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:49c385fefc6d43c1f94792718d0f6bdb3dec894239d1118cfcceb48a4eaa495c", size = 771443, upload-time = "2026-08-04T21:00:35.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/9a/8e9ecb2d0d1608e64cadca9297654c07fecbef8d66a9dce5d26db02bdf19/hypothesis-6.165.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:559f37d914f2a7c5d2b28b3ef7282814992082c1492343fed644244d984208ce", size = 1100733, upload-time = "2026-08-04T21:01:07.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9c/68d9378aa849c3495d81630caabd2a6c99a4cbaee1290f2588ab050c1786/hypothesis-6.165.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0447adc4168062fb58d1dbaa51031eaa991d39293dd6c70ec5818249b9636eca", size = 1129326, upload-time = "2026-08-04T21:01:03.82Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d4/97fcc4d2fc69c71856cc4b7ff8f85d00d0cdc9218e8272630e52a83e8cae/hypothesis-6.165.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:829a45c5459f7070277ac0fb0e7b052a7d9bdc2f54a546bfc34279213b6fa858", size = 1150180, upload-time = "2026-08-04T21:00:42.104Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1f/451f6ab6d0a19d9b0dae2cc8bf6f385321838aab0c99675117900b494d44/hypothesis-6.165.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:5b6ef453c54059493b1fbe3a281c5884e3a53f58bb65cac2c2af41c88437b5f1", size = 1105562, upload-time = "2026-08-04T21:01:05.613Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b2/2ca31fd5262addcff75eaa936d2a5883fac72affcfa3aa4d30e6af05a688/hypothesis-6.165.1-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6e12d8c8dca8fc6a16c25929370967450c062f1b75c74ce5bd881f82ce0aff6e", size = 1142296, upload-time = "2026-08-04T21:01:28.47Z" },
+    { url = "https://files.pythonhosted.org/packages/14/90/87fd3644fcd27d3b29f3786c53e6d518c1524e07859effd1e664293fc14b/hypothesis-6.165.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:653c596f6dd6fe5f4bdaf2618b8a4806540f1fa44749ec76d6788dc5e701616a", size = 1274544, upload-time = "2026-08-04T21:00:53.554Z" },
+    { url = "https://files.pythonhosted.org/packages/06/13/4b5cbbd5a2c5c376e84832853926c2b16dd258cde6c29799fc7575cc36c6/hypothesis-6.165.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:bdb85f80e55d9a0dd922225922b432d4dffe62d38d936e5312dd83b677570c0f", size = 1402353, upload-time = "2026-08-04T21:01:40.308Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/de/2ee85a3b3156d2f81ac03616ec57abd02871b84cc42caa4f213143209e20/hypothesis-6.165.1-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:a6751413ce069adc995292e9220b99716c0b908c141e89c49885e15dfad8ca13", size = 1275154, upload-time = "2026-08-04T21:01:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/96/18bf5d2ffd00b33a7dd98fdf6129fb7e021a235447e63b8ce47cc6e7b535/hypothesis-6.165.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ac26ad69d2d1871bdb6ac6d2be7bce5b03fef376724f50ade5419248d989ba14", size = 1317213, upload-time = "2026-08-04T21:01:54.815Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f9/a24c2eefb7f76bf1ba0c650acc67a542a5df71ee824c3979f389394e2c22/hypothesis-6.165.1-cp310-abi3-win32.whl", hash = "sha256:24a14ec42347ccd8f9153cc6486b32bf402afc0187d80e6a268a94b1468a72ce", size = 661724, upload-time = "2026-08-04T21:01:13.09Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/15/b6e98c68799f381123c872ca3493f1eb400b0e28550be938d1d3d63743c2/hypothesis-6.165.1-cp310-abi3-win_amd64.whl", hash = "sha256:d30337baadfdaccf0ad6d70fe135201722f67f7522584b2a7494cfd7e03798a6", size = 667859, upload-time = "2026-08-04T21:01:11.382Z" },
+    { url = "https://files.pythonhosted.org/packages/50/34/6cc747835aebec9d481b908c762bf552beec2ae7b95d1db3de40a66ef120/hypothesis-6.165.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:2dac5c816124efec59dcb8117a4a521e0647faad1041c5280d0009304145ad79", size = 776390, upload-time = "2026-08-04T21:00:55.428Z" },
+    { url = "https://files.pythonhosted.org/packages/65/da/98025b789cc9ed7e1136176b3528029ee0c758733cfedc8963f6671e4c7b/hypothesis-6.165.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2d3bf3b4035271024f215ae592b4adeaf5c95569b8a64362f358e6c2fa1fe83", size = 772175, upload-time = "2026-08-04T21:00:20.007Z" },
+    { url = "https://files.pythonhosted.org/packages/df/47/4689ddf832a43bcb2fff4045aa37ba3eb5387ede2648488d010d61fc0cdc/hypothesis-6.165.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52a23badd21024ea3e4767121ed47309a349171e0614ce0069037d891e68a0f9", size = 1101069, upload-time = "2026-08-04T21:00:32.251Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/25/b71cac1cc16d633c4b8da876a078d55e1e6b2702acbbc701492390c01cfc/hypothesis-6.165.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f57a7340e2cfbb0143b9d1cbe982d663560f0eef39e6aa99c6a711f29c072c27", size = 1150514, upload-time = "2026-08-04T21:01:52.536Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/c3/525a172b253c7731df33077a2100c270ca4cc257660b6c8b0a5910cb079c/hypothesis-6.165.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5b06157aca825440da903616abce01fea604342f7516ed8fdd3065ad25f84068", size = 1274890, upload-time = "2026-08-04T21:01:00.579Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c5/905b236db69d8923b3f1821cadfdab6494177bd7e37318f4410756b0d82a/hypothesis-6.165.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7b5165e043efffbbcabb8ee3fea05e93a05e670cfe03fda46321b2772f6c2d9b", size = 1317486, upload-time = "2026-08-04T21:01:58.519Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/8d/4d226b095da3e1b99d7e5d3621f3f964f2a7b5bfbbb82126992a8f6e799b/hypothesis-6.165.1-cp311-cp311-win_amd64.whl", hash = "sha256:9763c1cb9dd6b9a1ab395481d4067b2e8a3b148a97e599b419788e8775106b54", size = 667598, upload-time = "2026-08-04T21:01:34.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/48/7a8de755d9b9cab7caa9ef9051ffa2a5a21f7b20f813c902b0123952ed33/hypothesis-6.165.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:53b3d1e8ed9140994955f7bf27c185d45a475dc9d4bc95c69e7bd48b5c3c426f", size = 777509, upload-time = "2026-08-04T21:01:14.907Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2b/97224357923b13c3dd84ebbcd39bd414368543306e60b72b72deb0743f4a/hypothesis-6.165.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8f4b0e0664e058fdf1637d1ca9d984e5286372ad58b70222195dc535a771c4bd", size = 769074, upload-time = "2026-08-04T21:00:48.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f4/e00e850e4e3b1d25b2b7b6528b8fc0dd3ce5c5989cdb4863b6b9cd814b06/hypothesis-6.165.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616df752e3b2f8db6e463a86ad42942024094050adf4406bda4543b6b91333c3", size = 1099519, upload-time = "2026-08-04T21:00:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/cb/24498d5b5a0d73c780a31d9b2269ff032cdacb772a986f8fb52444aa3dae/hypothesis-6.165.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38a67b9f6807dade978d293be183c7487968a9c3c9a656c33effd75ddc8405f8", size = 1149568, upload-time = "2026-08-04T21:00:45.151Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5b/7da5727dbdf8d72a223270c97b0ab385dd24e9211539f98ed92aefd73adc/hypothesis-6.165.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62e1022d7eb78819e7256ed169ddbee5c19aaa0cacd5b9f30d30bb0f5d8c9ac2", size = 1272333, upload-time = "2026-08-04T21:00:17.665Z" },
+    { url = "https://files.pythonhosted.org/packages/55/3c/008ecb11ef2fa92f5c70c2a657c6c780a952f5a910f985ea886cff2f3e2a/hypothesis-6.165.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c8cd6fd2336d318a7aa42c492ffb2996a91dd050a27e732226a6a570bfc08725", size = 1316542, upload-time = "2026-08-04T21:00:57.156Z" },
+    { url = "https://files.pythonhosted.org/packages/08/85/ee8ea059d01971fd7c0d9498911eac5b94ef6678a39575eebe37fdf2d49b/hypothesis-6.165.1-cp312-cp312-win_amd64.whl", hash = "sha256:16b63ec033a0dceb6e00da6cc5d49bb38803c6825ca68f52604e424a2e3682ed", size = 665024, upload-time = "2026-08-04T21:01:50.588Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ae/6154945a7603e305273f98fc10bc3364a6e67d347ff810e02f864a7b7843/hypothesis-6.165.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:57c235a348b544455e13300e6cf11e0bf3eea4b692331beb42854edc8e661045", size = 777400, upload-time = "2026-08-04T21:01:48.265Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/75/3817a4878664895e2f9c5518aa4918366db5bc2521a6498e480a6ada1b1c/hypothesis-6.165.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:28b1aae4f2cf6cb99d34b1979d06d21f36ef771afb42418c9243da145e36e09a", size = 769040, upload-time = "2026-08-04T21:00:50.295Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/12/34d55b84b761448f76a493e1d71ce1ceb0529a92db013635e74dbbd64030/hypothesis-6.165.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33fb3293d3b7a56749b34ac64012540bec5c4d2ca701fa47a88cbc88846d1228", size = 1099438, upload-time = "2026-08-04T21:00:37.215Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/23/cf88d3ec0521089258000ff17d3a6bd13c78c2efcfaaece9af06e5b0f2d5/hypothesis-6.165.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ca1f560b9b0a9b000619d199748994eb8703915bbaf60a5377feaf296f7514f", size = 1149379, upload-time = "2026-08-04T21:01:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d7/cd397baad6a559cc60c3479e4e70013aafe631f29df74e14a29efaf58572/hypothesis-6.165.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d48b5f390601129fd70bed088883ca80a4cefaf515a85af21c5a4bce35e207a8", size = 1272381, upload-time = "2026-08-04T21:00:21.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/11/3bb75e5517823ff41220b35862e0af353b183941ff63019e3db8203083a8/hypothesis-6.165.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d10c79518af6da3fe64107a47dd8c2cc1094b92245976c5b38c0004222d2dd54", size = 1316256, upload-time = "2026-08-04T21:01:32.206Z" },
+    { url = "https://files.pythonhosted.org/packages/54/d5/eda5cc31ac6c56a238ae5b341737c812fbc1fb84e93ad47088da96f4a953/hypothesis-6.165.1-cp313-cp313-win_amd64.whl", hash = "sha256:55ed0599c5e5fdf7ada0b48ee1de05f314bcf6f01e49ad92a786da3d169c9d1c", size = 665035, upload-time = "2026-08-04T21:00:24.428Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/c5/d7c53d4e6a76f2d27a2179e9ea80ebcc76dcc151e17fa4df07efb943c7ae/hypothesis-6.165.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:99c0b348dd0090418ecac8e3f072e7db8f3d4d745b80ed29cb7e6413eba578d5", size = 777613, upload-time = "2026-08-04T21:01:46.361Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ad/d1854bb869e840c0406a271a5f9e82377900317aad38c51a05d31f783df6/hypothesis-6.165.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d37ca9b20de6413e931280fce4428cf49ed769dc421d80b4ecce2b2e47266eae", size = 769175, upload-time = "2026-08-04T21:01:18.729Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/5b/eecf6b1ad0d41007f88a3347be19e83fb04d53dffcc7c372e20b509bc366/hypothesis-6.165.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2dbf82a127e4a598745e6708535dab8e5dafbe498664b6dfaf451f305a8b3fc", size = 1099937, upload-time = "2026-08-04T21:00:27.566Z" },
+    { url = "https://files.pythonhosted.org/packages/55/9b/c58c4910cf6766857a7dd31da294f32b26d03e94d05b225c0dcc83fb41b9/hypothesis-6.165.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b60824e0a15dd712d0ac93940029cdc79f5a10f1e9289ec0a82bddd8d43a3c4", size = 1149618, upload-time = "2026-08-04T21:00:12.05Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/34b0228ab9949bd8b198076a779f7114e241b87ff1ae9d32556d7dc3c397/hypothesis-6.165.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:811bb434b1b8593f377daa73acd1e52bcc9cc556dc0cc947ca50e67d0a8dbdb2", size = 1272714, upload-time = "2026-08-04T21:02:03.503Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/a7895444c85d834ae9bf3ca4190f4a0b07a307735ada504477aee98a2408/hypothesis-6.165.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5e01cce4e2f7aac0e5d9be41d4920bfeb6f8dda9289f12b64dff32734f421837", size = 1316542, upload-time = "2026-08-04T21:02:00.69Z" },
+    { url = "https://files.pythonhosted.org/packages/49/98/4777c98b9fa75b9f0422ebfed218e27167c00c6d56b3336bb6b5d9e22952/hypothesis-6.165.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:849963a2c45ce04ceb1fb32ae5121bb0b70e515e86f8e7d752330f24d5361b06", size = 609126, upload-time = "2026-08-04T21:00:58.736Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/98603203f2e7838c180bd2b3bd32c07aecc02d62ce46d040cba4d1b892e9/hypothesis-6.165.1-cp314-cp314-win_amd64.whl", hash = "sha256:6bb8b5899151b35b4453face837536430c3835aabb71431b60ef26f4281a386e", size = 664903, upload-time = "2026-08-04T21:00:43.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/56/22bdc2f83c1457398f996ca11fe3b346cd3852f8efe9517ac841ef86a076/hypothesis-6.165.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:cf7557e571a36809bee6979c9457a3e00d63f4c771b64985f610cdb74223b3be", size = 776196, upload-time = "2026-08-04T21:01:30.284Z" },
+    { url = "https://files.pythonhosted.org/packages/77/db/8767634d5ea1c15f35866fcddcf28243491369f7c76fab7be3b1aa4982ce/hypothesis-6.165.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d2ad504983c3d65c96e8ea5f29bb43fe1c6ff5e7446e2a01a1c5882e1f31ec3a", size = 767642, upload-time = "2026-08-04T21:01:38.26Z" },
+    { url = "https://files.pythonhosted.org/packages/46/26/4c6219cf21dea687944a1ca2923fbb2e425efe451dedd2949df31bcc5581/hypothesis-6.165.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:208ceb4bdbb0b1f399926c0fac4d69f03059bd530edefa43e35e3e010b97d3be", size = 1098532, upload-time = "2026-08-04T21:01:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/37/76/008d7d746d24a2dd4eaf4f2baa8b8b93e54a5790b11ad1d331c979ef5230/hypothesis-6.165.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79af38746023247c93fda5dfa56dbaafe11ce1553ba3fd7f10c7868cbc077d62", size = 1148486, upload-time = "2026-08-04T21:00:29.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fd/85daad6555629f740b1abc810efa23b7fed2405688d2ca90954bcb1c6c94/hypothesis-6.165.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a17b70c578e0d30608020502539c213405bd4f93e36804bed43214892e846c6b", size = 1270952, upload-time = "2026-08-04T21:00:33.798Z" },
+    { url = "https://files.pythonhosted.org/packages/49/27/e998674ef659d990c3b65508d72d0dafc3b62a665f20fefeb791cf06bf2b/hypothesis-6.165.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f3519acd1eb46ad6820f83daab301ef9429317976fc331d4878281808439d8e4", size = 1315358, upload-time = "2026-08-04T21:01:42.435Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/503f043020ee95697bf829dd118d8b77509254f524b74d1644c3f4bfe9f3/hypothesis-6.165.1-cp314-cp314t-win_amd64.whl", hash = "sha256:b5bd8e3b54f95a53d31da0e020e7bf57aa2cdce91babf5f84cd4b069cf4f2962", size = 665043, upload-time = "2026-08-04T21:01:16.916Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/ee/2e7f3b4fd174adb198f4ea458b4b9365ec5f17ba7df0faed2359935aa8c1/hypothesis-6.165.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1b1d2311e279c2b2d4770f7f48399e5b9e0a1ca7b496a67e455a1c814a5cb2f5", size = 777317, upload-time = "2026-08-04T21:01:44.301Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/e16eeffe05ad10b4d1e1374bfc2d343c832ef5133b377896c4a1bd852ab0/hypothesis-6.165.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:63d1b0903cfe1eb44a6ed080b1bf553819b48aa51059e0bed862ab6289d4ca7e", size = 773170, upload-time = "2026-08-04T21:01:24.807Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f0/28ce96c8aa95cc1155cab4ba8be8dc35052b2b85b441d39763ed2ca390cc/hypothesis-6.165.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02569a32a65da0b0a1fd27b24e94f9b3eef534f351d56c63036632e5d884cf89", size = 1102039, upload-time = "2026-08-04T21:00:30.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ed/9d1fb1c006e175773d589d6af225a19df89519a82dbf3dedcca238d328d9/hypothesis-6.165.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e904b427691743564f36f79d75f8698fa683d904c1e0a64b8a3907d27c688798", size = 1151774, upload-time = "2026-08-04T21:00:22.929Z" },
+    { url = "https://files.pythonhosted.org/packages/55/1e/59c8e440e655beb92df54e2c743d8daa139ceaae3f8a9447d972d0db8384/hypothesis-6.165.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2ee14e51fa732cbd026bbef25f48bfeb651eca8188742d1d36108d1dd6f65e95", size = 668692, upload-time = "2026-08-04T21:01:56.633Z" },
 ]
 
 [[package]]
@@ -390,6 +457,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #106.

## What

`StringInterpolate.from_lark` split patterns with `string.Formatter().parse`, which applies Python
*format-spec* semantics to text that is actually a dftly expression. Replaced with a brace-matching
scanner (`_split_interpolation` / `_scan_interpolation_field`).

## The two bugs

**Casts were silently dropped.** Everything after the first `:` was read as a format spec and then
discarded, so `f"{$a::int}"` evaluated as `f"{$a}"` with no error:

```pycon
>>> pl.DataFrame({"dose": [3.7]}).select(**Parser.to_polars({"v": 'f"{$dose::int}"'}))["v"].to_list()
['3.7']     # before — the ::int vanished
['3']       # after
```

`$a[0:3]` survived only because the formatter special-cases `[...]` when splitting — which made the
rule impossible to predict: subscripts kept their colon, casts didn't.

**Brace quantifiers failed to parse.** `{` inside a field read as a nested replacement field, so
``f"{extract /([0-9]{2})/ from $x}"`` raised `unexpected '{' in field name`, naming neither cause nor
workaround. (The README example added in #104 used `[0-9][0-9]` to sidestep exactly this; it's back to
`{2}` in this PR.)

## Approach

Fields are delimited by brace *depth*, with braces inside quoted strings ignored — mirroring the
escaping rules of the `STRING` terminal in `grammar.lark`, so `` f"{$a ?? '}'}" `` means what it looks
like. Contents go to the grammar verbatim: no `:`/`!` split, because dftly has no format specs or
conversions to split off. `{{`/`}}` stay literal braces, unchanged.

Errors are now loud and positional:

```pycon
>>> _split_interpolation("a } b")
ValueError: Unmatched `}` at position 2 of 'a } b'; write `}}` for a literal brace.
```

Unterminated fields and empty `{}` likewise.

## Behavior changes worth a look

- `f"{$a:>10}"` and `f"{$a!r}"` previously parsed (spec/conversion silently dropped); they now reach
  the grammar and fail there. That's the intended trade — dftly has no formatting semantics, and
  `pl.format` has none to forward, so accepting the syntax could only ever mean ignoring it.
- Anything that was *working* before is unaffected: the field text of a spec-free field is identical
  under both splitters, and the full suite (including every existing f-string doctest) passes.
- One limitation left in place, not introduced here: `pl.format` recognizes `{}` as a placeholder and
  has no escape, so a pattern whose *literal* text contains `{}` (`f"{{}}"`) still can't be expressed.
  Worth its own issue if it ever comes up.

Doctests cover both scanner helpers directly, plus an end-to-end block in `StringInterpolate` and a
new README section on what may appear inside a field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)